### PR TITLE
[Fix] Remove a trailing slash in cmuclmtk installation instruction.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -43,7 +43,7 @@ To install cmuclmtk :
 
     ./configure
     make
-    sudo make install/
+    sudo make install
 
 You may have to run `sudo ldconfig` to fix errors such as missing shared library.
 


### PR DESCRIPTION
Trail showing error so ignoring that