### PR TITLE
Fixed typos in comments/output in src files

### DIFF
--- a/src/lib_ccaligner/generate_approx_timestamp.cpp
+++ b/src/lib_ccaligner/generate_approx_timestamp.cpp
@@ -220,7 +220,7 @@ std::vector<SubtitleItem *, std::allocator<SubtitleItem *>> ApproxAligner::align
         CurrentSub * currSub = new CurrentSub(sub);
         currSub->run();
 
-        switch (_outputFormat)  //decide on based of set output format
+        switch (_outputFormat)  //decide on basis of set output format
         {
             case srt:       subCount = printSRTContinuous(_outputFileName, subCount, sub, printBothWihoutColors);
                 break;

--- a/src/lib_ccaligner/grammar_tools.cpp
+++ b/src/lib_ccaligner/grammar_tools.cpp
@@ -22,7 +22,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
         name = complete_grammar;
     }
 
-    //create temporary directories in case it doesn't exist
+    //create temporary directories in case they don't exist
     LOG("Creating temp directories at tempFiles/");
 
     int rv = std::system("mkdir -p tempFiles/corpus tempFiles/dict tempFiles/vocab tempFiles/fsg tempFiles/lm");
@@ -266,7 +266,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
             if (WIFEXITED(rv) && WEXITSTATUS(rv) != 0)
             {
-                FATAL(EXIT_FAILURE, "Something went wrong while moving phonetic model!s");
+                FATAL(EXIT_FAILURE, "Something went wrong while moving phonetic model!");
             }
         }
 
@@ -304,7 +304,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
         if (WIFEXITED(rv) && WEXITSTATUS(rv) != 0)
         {
-            FATAL(EXIT_FAILURE, "Something went wrong while moving phonetic model!s");
+            FATAL(EXIT_FAILURE, "Something went wrong while moving phonetic model!");
         }
     }
 

--- a/src/lib_ccaligner/params.cpp
+++ b/src/lib_ccaligner/params.cpp
@@ -518,7 +518,7 @@ void Params::validateParams()
     {
         outputFileName = extractFileName(audioFileName);
 
-        switch (outputFormat)  //decide on based of set output format
+        switch (outputFormat)  //decide on basis of set output format
         {
             case srt:       outputFileName += ".srt";
                 break;

--- a/src/lib_ccaligner/recognize_using_pocketsphinx.cpp
+++ b/src/lib_ccaligner/recognize_using_pocketsphinx.cpp
@@ -518,7 +518,7 @@ bool PocketsphinxAligner::recognise()
         if(_parameters->searchPhonemes)
             recognisePhonemes(sample + samplesAlreadyRead, samplesToBeRead, sub);
 
-        switch (_parameters->outputFormat)  //decide on based of set output format
+        switch (_parameters->outputFormat)  //decide on basis of set output format
         {
             case srt:       subCount = printSRTContinuous(_outputFileName, subCount, sub, _parameters->printOption);
                 break;
@@ -822,7 +822,7 @@ bool PocketsphinxAligner::alignWithFSG()
 
         recognisedBlock currBlock = findAndSetWordTimes(subConfig, _psWordDecoder, sub);
 
-        switch (_parameters->outputFormat)  //decide on based of set output format
+        switch (_parameters->outputFormat)  //decide on basis of set output format
         {
             case srt:       subCount = printSRTContinuous(_outputFileName, subCount, sub, _parameters->printOption);
                 break;
@@ -854,7 +854,7 @@ bool PocketsphinxAligner::alignWithFSG()
 
 bool PocketsphinxAligner::printAligned(std::string outputFileName, outputFormats format)
 {
-    switch (format)  //decide on based of set output format
+    switch (format)  //decide on basis of set output format
     {
         case srt:       printSRT(outputFileName, _subtitles, _parameters->printOption);
                         break;


### PR DESCRIPTION
**[FIX]**
Fixed typos in comments in 4 files : generate_approx_timestamp.cpp ; grammar_tools.cpp ; recognize_using_pocketsphinx.cpp & params.cpp in src/lib_ccaligner