### PR TITLE
Removed unnecessary condition.

### DIFF
--- a/src/lib_ext/srtparser/srtparser.h
+++ b/src/lib_ext/srtparser/srtparser.h
@@ -204,7 +204,7 @@ inline std::vector<std::string> &split(const std::string &s, char delim, std::ve
 
 inline bool isPunc(char ch)
 {
-    return (ch == '!' || ch == '?' || ch == '.' || ch == ',' || ch == '"' || ch == '-' || ch ==':' || !((unsigned char) ch >= 0 && (unsigned char) ch < 128));
+    return (ch == '!' || ch == '?' || ch == '.' || ch == ',' || ch == '"' || ch == '-' || ch ==':' || (unsigned char) ch >= 128);
 }
 
 /**** Class definitions ****/


### PR DESCRIPTION
An `unsigned char` is always positive or zero, so that condition is unnecessary. Removing and merging the not operator at the same time.