### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -92,7 +92,7 @@ To install g2p-seq2seq :
 
     python setup.py install
     
-You will also need to install http://www.perl.org/get.html[Perl] and move install/quick_lm.pl to the same directory as the CCAligner or a dictionary that is set in the environment variable PATH
+You will also need to install http://www.perl.org/get.html and move install/quick_lm.pl to the same directory as the CCAligner or a dictionary that is set in the environment variable PATH
     
 === Before You Run ===
 


### PR DESCRIPTION
Line 95: You will also need to install http://www.perl.org/get.html[Perl] and move install/quick_lm.pl to the same directory as the CCAligner or a dictionary that is set in the environment variable PATH
 http://www.perl.org/get.html[Perl] changed to http://www.perl.org/get.html for accessing the sites for download