### PR TITLE
A Logger

### DIFF
--- a/docs/code_documentation.adoc
+++ b/docs/code_documentation.adoc
@@ -63,7 +63,7 @@ asrAligner,             //using pocketsphinx as ASR
 alignerUnassigned       //no aligner is specified
 ```
 
-2 `outputFormats`	: Enum for various possible output formats.
+2. `outputFormats`	: Enum for various possible output formats.
 
 ```
 srt,
@@ -88,7 +88,8 @@ quick_dict,
 quick_lm,
 no_grammar
 ```
-5. `outputOptions`	: Enum for various output characteristics.
+
+4. `outputOptions`	: Enum for various output characteristics.
 
 ```
 printOnlyRecognised,
@@ -142,14 +143,15 @@ To log:
 DEBUG << "Creating temporary directories at tempFiles/";
 INFO << "Grammar files created!";
 WARNING << "The value is "<<value<<" but it is expected to be " << exceptedValue;
-FATAL(EXIT_INVALID_PARAMETERS) << "Unsupported Aligner Type!";
+FATAL(InvalidParameters) << "Unsupported Aligner Type!";
 ```
 
-VERBOSE: Information for tracing
-DEBUG: Information for developers
-INFO: Information for general users
-WARNING: Problems that may affect facility, performance or stability but may not lead the program to crash immediately
-ERROR(code): Something unexpected happened but can be recoveredc(code): Unrecoverable error and program termination is required. ``code`` will be the exit code of the program (Except for code == DO_NOT_EXIT, where the program won't exit)
+- VERBOSE: Information for tracing
+- DEBUG: Information for developers
+- INFO: Information for general users
+- WARNING: Problems that may affect facility, performance or stability but may not lead the program to crash immediately
+- ERROR: Something unexpected happened but can be recovered
+- FATAL(ExceptionType): Unrecoverable error and program termination is required. `ExceptionType` will be type of exception thrown at the end of the log. It will be constructed by a std::string parameter which is the content of the log.
 
 # generate_approx_timestamp.h and generate_approx_timestamp.cpp
 

--- a/docs/code_documentation.adoc
+++ b/docs/code_documentation.adoc
@@ -30,6 +30,8 @@ All the technical details are commented in the codes and the documentation is av
     │   ├── generate_approx_timestamp.h
     │   ├── grammar_tools.cpp
     │   ├── grammar_tools.h
+    │   ├── logger.cpp
+    │   ├── logger.h
     │   ├── output_handler.cpp
     │   ├── output_handler.h
     │   ├── params.cpp
@@ -53,10 +55,7 @@ All the technical details are commented in the codes and the documentation is av
 
 These files contain enums, functions and classes that provide common functionalities throught the project. These include options, enums, global variables, logging and error functions, some helper functions and a class used to store aligned data.
 
-
-1. `should_log` 	: Boolean global variable determining whether to enable logging or not.
-
-2. `alignerType`	: Enum for typef of aligner to perform the force alignment.
+1. `alignerType`	: Enum for typef of aligner to perform the force alignment.
 
 ```
 approxAligner,          //approximation based alignment
@@ -64,7 +63,7 @@ asrAligner,             //using pocketsphinx as ASR
 alignerUnassigned       //no aligner is specified
 ```
 
-3. `outputFormats`	: Enum for various possible output formats.
+2 `outputFormats`	: Enum for various possible output formats.
 
 ```
 srt,
@@ -75,7 +74,7 @@ console,
 blank               //means no output format is specified
 ```
 
-4. `grammarName`	: Enum for various possible output formats.
+3. `grammarName`	: Enum for various possible output formats.
 
 ```
 corpus,
@@ -90,7 +89,7 @@ quick_lm,
 no_grammar
 ```
 
-5. `outputOptions`	: Enum for various output characterstics.
+4. `outputOptions`	: Enum for various output characterstics.
 
 ```
 printOnlyRecognised,
@@ -100,29 +99,13 @@ printAsKaraoke,
 printAsKaraokeWithDistinctColors,
 ```
 
-6. `LOG()` and `log()` : Logger functions to help log events throught the project.
+5. `ms_to_srt_time(long int ms, int *hours, int *minutes, int *seconds, int *milliseconds)` : convert milliseconds to subtitle time format.
 
-Example :
+6. `extractFileName(std::string fileName)` : Extract path/to/filename from path/to/filename.extension and return as std::string.
 
-```
-LOG("Reading wave file from stream..");
-```
+7. `StringToLower(std::string strToConvert)` : Convert string into lowercase. Retrun type : std::string.
 
-7. `FATAL()` and `fatal()` : Error functions to exit program on catching a fatal error.
-
-Example :
-
-```
-FATAL(EXIT_FAILURE, "Invalid value passed to -sampleWindow : %s", strerror(errno));
-```
-
-8. `ms_to_srt_time(long int ms, int *hours, int *minutes, int *seconds, int *milliseconds)` : convert milliseconds to subtitle time format.
-
-9. `extractFileName(std::string fileName)` : Extract path/to/filename from path/to/filename.extension and return as std::string.
-
-10. `StringToLower(std::string strToConvert)` : Convert string into lowercase. Retrun type : std::string.
-
-11. `AlignedData` : Used to store transcribed data. All members are public.
+8. `AlignedData` : Used to store transcribed data. All members are public.
 
 ```
 {
@@ -145,6 +128,29 @@ public:
 };
 
 ```
+
+# logger.h and logger.cpp
+
+To initialize:
+```
+Logger::Sink sink(logFile, false); // logFile is a std::ofstrea; false means don't use color for this sink.
+sink.setMinimumOutputLevel(Logger::Level::verbose); // forward all logs to the log file.
+getLogger().addSink(sink); // add a log file. (std::cout is automatically added)
+```
+
+To log:
+```
+DEBUG << "Creating temporary directories at tempFiles/";
+INFO << "Grammar files created!";
+WARNING << "The value is "<<value<<" but it is expected to be " << exceptedValue;
+FATAL(EXIT_INVALID_PARAMETERS) << "Unsupported Aligner Type!";
+```
+
+VERBOSE: Information for tracing
+DEBUG: Information for developers
+INFO: Information for general users
+WARNING: Problems that may affect facility, performance or stability but may not lead the program to crash immediately
+ERROR(code): Something unexpected happened but can be recoveredc(code): Unrecoverable error and program termination is required. ``code`` will be the exit code of the program (Except for code == DO_NOT_EXIT, where the program won't exit)
 
 # generate_approx_timestamp.h and generate_approx_timestamp.cpp
 

--- a/docs/usage_parameters.adoc
+++ b/docs/usage_parameters.adoc
@@ -29,11 +29,7 @@ _E.g.: ``ccaligner -raw tbbt.raw -srt tbbt.srt``_
 
 _E.g.: ``ccaligner -wav tbbt.wav -srt tbbt.srt``_
 
-|`-txt`
-|`/path/to/text/file`
-|Provide path to transcript file in txt format. Only transcription works with this parameter. (See: -transcribe)
-
-_E.g.: ``ccaligner -wav tbbt.wav -txt tbbt.txt``_
+Required : yes.
 
 |`-stdin` or `-`
 |Audio wave file from stdin or pipe.
@@ -68,14 +64,20 @@ _E.g.: ``ccaligner -wav tbbt.wav -srt tbbt.srt -out my_output.xml``_
 _E.g.: ``ccaligner -wav tbbt.wav -srt tbbt.srt -out output_as_karaoke.srt -oFormat karaoke``_
 
 |`-log`
-|`/path/to/aligner_log_file/`
-|Specify path to logfile for PocketSphinx decoder. By default stores log in `tempFiles/{execution_timestamp}.log`
+|`/path/to/program_log_file/`
+|Specify path to logfile for the program. By default stores log in `tempFiles/{execution_timestamp}.log`
 
 _E.g.: ``ccaligner -wav tbbt.wav -srt tbbt.srt -log tbbt.log``_
 
+|`-alignerLog`
+|`/path/to/aligner_log_file/`
+|Specify path to logfile for the PocketSphinx decoder. By default stores log in `tempFiles/aligner-{execution_timestamp}.log`
+
+_E.g.: ``ccaligner -wav tbbt.wav -srt tbbt.srt -alignerLog tbbt.log``_
+
 |`-phoneLog`
 |`/path/to/phoneme_log_file/`
-|Specify path to logfile for PocketSphinx phoneme decoder. By default stores log in `tempFiles/phoneme_{execution_timestamp}.log`
+|Specify path to logfile for PocketSphinx phoneme decoder. By default stores log in `tempFiles/phoneme-{execution_timestamp}.log`
 
 _E.g.: ``ccaligner -wav tbbt.wav -srt tbbt.srt -phoneLog tbbt_phoneme.log``_
 |===
@@ -203,10 +205,10 @@ _E.g.: ``ccaligner -wav tbbt.wav -srt tbbt.srt --quick-dict yes``_
 | Parameter | Accepted Values | Description
 
 |`-verbose`
-|`yes`, `no`
-|Turns verbosity on and off. Turn off for preventing [info] logs.
+|`verbose`, `debug`, `info`, `warning`, `error`, `nolog`
+|Change log level. Change to `nolog` to prevent log. Default setting is `debug`.
 
-_E.g.: ``ccaligner -wav tbbt.wav -srt tbbt.srt -verbose no``_
+_E.g.: ``ccaligner -wav tbbt.wav -srt tbbt.srt -verbose info``_
 
 |`--display-recognised`
 |`yes`, `no`

--- a/docs/usage_parameters.adoc
+++ b/docs/usage_parameters.adoc
@@ -31,6 +31,12 @@ _E.g.: ``ccaligner -wav tbbt.wav -srt tbbt.srt``_
 
 Required : yes.
 
+|`-txt`
+|`/path/to/text/file`		
+|Provide path to transcript file in txt format. Only transcription works with this parameter. (See: -transcribe)		
+
+_E.g.: ``ccaligner -wav tbbt.wav -txt tbbt.txt``_
+
 |`-stdin` or `-`
 |Audio wave file from stdin or pipe.
 |Use this parameter to pass wav file from `stdin` or pipe.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,6 +87,8 @@ set(SOURCE_FILES
         lib_ccaligner/phoneme_utils.h
         lib_ccaligner/output_handler.cpp
         lib_ccaligner/output_handler.h
+        lib_ccaligner/logger.cpp
+        lib_ccaligner/logger.h
         )
 
 add_executable(ccaligner ${SOURCE_FILES})

--- a/src/ccaligner.cpp
+++ b/src/ccaligner.cpp
@@ -40,10 +40,18 @@ void printFooter()
     std::cout<<"https://github.com/saurabhshri/CCAligner/issues\n";
 }
 
-CCAligner::CCAligner(Params* parameters)
+CCAligner::CCAligner(Params* parameters) : logFile(parameters->logPath)
 {
     _parameters = parameters;
-    //should_log = _parameters->verbosity;
+  
+    Logger::Sink sink(logFile, false);
+    sink.setMinimumOutputLevel(Logger::Level::verbose);
+    getLogger().addSink(sink);
+
+}
+
+CCAligner::~CCAligner() {
+    logFile.close();
 }
 
 int CCAligner::initAligner()

--- a/src/ccaligner.cpp
+++ b/src/ccaligner.cpp
@@ -43,7 +43,7 @@ void printFooter()
 CCAligner::CCAligner(Params* parameters)
 {
     _parameters = parameters;
-    should_log = _parameters->verbosity ;
+    //should_log = _parameters->verbosity;
 }
 
 int CCAligner::initAligner()
@@ -60,7 +60,7 @@ int CCAligner::initAligner()
 
     else
     {
-        FATAL(EXIT_INVALID_PARAMETERS, "Unsupported Aligner Type!");
+        fatalstream(EXIT_INVALID_PARAMETERS) << "Unsupported Aligner Type!";
     }
 
     return 1;

--- a/src/ccaligner.cpp
+++ b/src/ccaligner.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "ccaligner.h"
+#include <typeinfo>
 
 void printUsage()
 {

--- a/src/ccaligner.cpp
+++ b/src/ccaligner.cpp
@@ -66,7 +66,7 @@ int CCAligner::initAligner()
     }
     else
     {
-        fatalstream(EXIT_INVALID_PARAMETERS) << "Unsupported Aligner Type!";
+        FATAL(EXIT_INVALID_PARAMETERS) << "Unsupported Aligner Type!";
     }
 
     return 1;

--- a/src/ccaligner.cpp
+++ b/src/ccaligner.cpp
@@ -48,6 +48,7 @@ CCAligner::CCAligner(Params* parameters) : logFile(parameters->logPath)
     sink.setMinimumOutputLevel(Logger::Level::verbose);
     getLogger().addSink(sink);
 
+    Logger::Log<>(getLogger(), __FILE__, __FUNCTION__, __LINE__, Logger::Level::verbose);
 }
 
 CCAligner::~CCAligner() {
@@ -66,7 +67,7 @@ int CCAligner::initAligner()
     }
     else
     {
-        FATAL(EXIT_INVALID_PARAMETERS) << "Unsupported Aligner Type!";
+        FATAL(InvalidParameters) << "Unsupported Aligner Type!";
     }
 
     return 1;
@@ -76,11 +77,18 @@ int main(int argc, char *argv[])
 {
     printHeader("0.03 Alpha [Shubham]");
 
-    Params parameters;
-    parameters.inputParams(argc, argv);
+    try {
+        Params parameters;
+        parameters.inputParams(argc, argv);
 
-    CCAligner(&parameters).initAligner();
-
+        CCAligner(&parameters).initAligner();
+    }
+    catch (std::exception& e) {
+        std::cerr << "Program aborted because an exception has occurred." << std::endl;
+        std::cerr << "Exception details:" << std::endl
+            << "Type: " << typeid(e).name() << ". " << std::endl
+            << "Reason: " << e.what() << std::endl;
+    }
     printFooter();
 
     return 0;

--- a/src/ccaligner.h
+++ b/src/ccaligner.h
@@ -13,12 +13,13 @@
 class CCAligner
 {
     Params * _parameters;
+    std::ofstream logFile;
 
 public:
 
     CCAligner(Params *parameters);
     int initAligner();                                  //initialize the aligner
-    ~CCAligner() = default;
+    ~CCAligner();
 };
 
 void printUsage();                                      //print usage instruction (soon to be added inside class)

--- a/src/lib_ccaligner/commons.cpp
+++ b/src/lib_ccaligner/commons.cpp
@@ -6,36 +6,6 @@
 
 #include "commons.h"
 
-bool should_log;
-
-/* Write formatted message to stderr and then exit. */
-void fatal(int exit_code, const char *fileName, const int lineNumber, const char *format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    fprintf(stderr, "\r\n\n\n[ERROR] %s : %d \n\t\t ", fileName, lineNumber);
-    vfprintf(stderr, format, args);
-    fprintf(stderr, "\n\n\n");
-    va_end(args);
-    std::exit(exit_code);
-}
-
-
-/* Shorten some debug output code. */
-void log(const char *fileName, const int lineNumber, const char *format, ...)
-{
-    if(should_log == false)
-        return;
-
-    va_list args;
-    va_start(args, format);
-    fprintf(stdout, "[INFO] %s : %d | ", fileName, lineNumber);
-    vfprintf(stdout, format, args);
-    fprintf(stdout, "\n");
-    fflush (stdout);
-    va_end(args);
-}
-
 void ms_to_srt_time(long int ms, int *hours, int *minutes, int *seconds, int *milliseconds)
 {
     *milliseconds = (int)(ms % 1000);

--- a/src/lib_ccaligner/commons.h
+++ b/src/lib_ccaligner/commons.h
@@ -17,8 +17,7 @@
 #include <regex>
 #include <cstdarg>
 #include <memory>
-
-extern bool should_log;
+#include "logger.h"
 
 enum alignerType
 {
@@ -60,22 +59,6 @@ enum outputOptions
     printAsKaraokeWithDistinctColors,
 
 };
-
-// Define possible exit codes that will be passed on to the fatal function exit codes.
-#define EXIT_OK                                 0
-#define EXIT_FILE_NOT_FOUND                     2
-#define EXIT_INVALID_PARAMETERS                 3
-#define EXIT_INCOMPATIBLE_PARAMETERS            4
-#define EXIT_INCOMPLETE_PARAMETERS              5
-#define EXIT_INVALID_FILE                       6
-#define EXIT_WITH_HELP                          10
-#define EXIT_UNKNOWN                            13
-
-#define LOG(MSG, ...) log(__FILE__, __LINE__, MSG, ##__VA_ARGS__)
-void log(const char *fileName, const int lineNumber, const char *format, ...);
-
-#define FATAL(ERR_NO, MSG, ...) fatal(ERR_NO, __FILE__, __LINE__, MSG, ##__VA_ARGS__)
-void fatal(int exit_code, const char *fileName, const int lineNumber, const char *format,  ...);
 
 void ms_to_srt_time(long int ms, int *hours, int *minutes, int *seconds, int *milliseconds); //converts ms to SRT time
 std::string extractFileName(const std::string& fileName);  //extract path/to/filename from path/to/filename.extension

--- a/src/lib_ccaligner/generate_approx_timestamp.cpp
+++ b/src/lib_ccaligner/generate_approx_timestamp.cpp
@@ -73,7 +73,7 @@ inline int CurrentSub::getDuration (long startTime, long endTime) const noexcept
 {
     if(endTime < startTime)
     {
-        fatalstream(EXIT_INVALID_FILE) << "Error! Incorrect start time and end time of the dialogue.";
+        FATAL(EXIT_INVALID_FILE) << "Error! Incorrect start time and end time of the dialogue.";
     }
 
     return endTime - startTime;
@@ -90,7 +90,7 @@ inline double CurrentSub::getWordWeight (const std::string& word) const noexcept
 void CurrentSub::assignTime(long int &wordDuration, const std::string &word )
 {
     if(_wordNumber>_wordCount)
-        fatalstream(EXIT_UNKNOWN) << "Oops! Something went wrong!";
+        FATAL(EXIT_UNKNOWN) << "Oops! Something went wrong!";
 
     double wordWeight = getWordWeight(word);
     wordDuration = wordWeight * _dialogueDuration;
@@ -223,7 +223,7 @@ std::vector<SubtitleItem *, std::allocator<SubtitleItem *>> ApproxAligner::align
             case console:   currSub.printToConsole(_outputFileName);
                 break;
 
-            default:        fatalstream(EXIT_UNKNOWN) << "An error occurred while choosing output format!";
+            default:        FATAL(EXIT_UNKNOWN) << "An error occurred while choosing output format!";
         }
 
     }

--- a/src/lib_ccaligner/generate_approx_timestamp.cpp
+++ b/src/lib_ccaligner/generate_approx_timestamp.cpp
@@ -74,7 +74,7 @@ inline int CurrentSub::getDuration (long startTime, long endTime) const noexcept
 {
     if(endTime < startTime)
     {
-        std::cout << "Error! Incorrect start time and end time of the dialogue.\n";
+        FATAL(EXIT_INVALID_FILE, "Error! Incorrect start time and end time of the dialogue.");
         return -1;
     }
 
@@ -92,7 +92,7 @@ inline double CurrentSub::getWordWeight (const std::string& word) const noexcept
 void CurrentSub::assignTime(long int &wordDuration, const std::string &word )
 {
     if(_wordNumber>_wordCount)
-        std::cout<<"Oops! Something went wrong!\n";
+        FATAL(EXIT_UNKNOWN, "Oops! Something went wrong!");
 
     double wordWeight = getWordWeight(word);
     wordDuration = wordWeight * _dialogueDuration;
@@ -228,8 +228,7 @@ std::vector<SubtitleItem *, std::allocator<SubtitleItem *>> ApproxAligner::align
             case console:   currSub.printToConsole(_outputFileName);
                 break;
 
-            default:        std::cout<<"An error occurred while choosing output format!";
-                exit(2);
+            default:        FATAL(EXIT_UNKNOWN, "An error occurred while choosing output format!");
         }
 
     }

--- a/src/lib_ccaligner/generate_approx_timestamp.cpp
+++ b/src/lib_ccaligner/generate_approx_timestamp.cpp
@@ -73,7 +73,7 @@ inline int CurrentSub::getDuration (long startTime, long endTime) const noexcept
 {
     if(endTime < startTime)
     {
-        FATAL(EXIT_INVALID_FILE, "Error! Incorrect start time and end time of the dialogue.");
+        fatalstream(EXIT_INVALID_FILE) << "Error! Incorrect start time and end time of the dialogue.";
         return -1;
     }
 
@@ -91,7 +91,7 @@ inline double CurrentSub::getWordWeight (const std::string& word) const noexcept
 void CurrentSub::assignTime(long int &wordDuration, const std::string &word )
 {
     if(_wordNumber>_wordCount)
-        FATAL(EXIT_UNKNOWN, "Oops! Something went wrong!");
+        fatalstream(EXIT_UNKNOWN) << "Oops! Something went wrong!";
 
     double wordWeight = getWordWeight(word);
     wordDuration = wordWeight * _dialogueDuration;
@@ -224,7 +224,7 @@ std::vector<SubtitleItem *, std::allocator<SubtitleItem *>> ApproxAligner::align
             case console:   currSub.printToConsole(_outputFileName);
                 break;
 
-            default:        FATAL(EXIT_UNKNOWN, "An error occurred while choosing output format!");
+            default:        fatalstream(EXIT_UNKNOWN) << "An error occurred while choosing output format!";
         }
 
     }

--- a/src/lib_ccaligner/generate_approx_timestamp.cpp
+++ b/src/lib_ccaligner/generate_approx_timestamp.cpp
@@ -74,7 +74,6 @@ inline int CurrentSub::getDuration (long startTime, long endTime) const noexcept
     if(endTime < startTime)
     {
         fatalstream(EXIT_INVALID_FILE) << "Error! Incorrect start time and end time of the dialogue.";
-        return -1;
     }
 
     return endTime - startTime;

--- a/src/lib_ccaligner/generate_approx_timestamp.cpp
+++ b/src/lib_ccaligner/generate_approx_timestamp.cpp
@@ -73,7 +73,7 @@ inline int CurrentSub::getDuration (long startTime, long endTime) const noexcept
 {
     if(endTime < startTime)
     {
-        FATAL(EXIT_INVALID_FILE) << "Error! Incorrect start time and end time of the dialogue.";
+        FATAL(InvalidFile) << "Error! Incorrect start time and end time of the dialogue.";
     }
 
     return endTime - startTime;
@@ -90,7 +90,7 @@ inline double CurrentSub::getWordWeight (const std::string& word) const noexcept
 void CurrentSub::assignTime(long int &wordDuration, const std::string &word )
 {
     if(_wordNumber>_wordCount)
-        FATAL(EXIT_UNKNOWN) << "Oops! Something went wrong!";
+        FATAL(UnknownError) << "Oops! Something went wrong!";
 
     double wordWeight = getWordWeight(word);
     wordDuration = wordWeight * _dialogueDuration;
@@ -223,7 +223,7 @@ std::vector<SubtitleItem *, std::allocator<SubtitleItem *>> ApproxAligner::align
             case console:   currSub.printToConsole(_outputFileName);
                 break;
 
-            default:        FATAL(EXIT_UNKNOWN) << "An error occurred while choosing output format!";
+            default:        FATAL(UnknownError) << "An error occurred while choosing output format!";
         }
 
     }

--- a/src/lib_ccaligner/grammar_tools.cpp
+++ b/src/lib_ccaligner/grammar_tools.cpp
@@ -74,7 +74,7 @@ void CreateNewGrammarFiles(grammarName name, std::ofstream &corpusDump, std::ofs
 
     if (name == corpus || name == complete_grammar)
     {
-        std::cout << "Creating Corpus : tempFiles/corpus/corpus.txt\n";
+        INFO << "Creating Corpus : tempFiles/corpus/corpus.txt";
 
         try
         {
@@ -89,7 +89,7 @@ void CreateNewGrammarFiles(grammarName name, std::ofstream &corpusDump, std::ofs
 
     if (name == phone_lm || name == complete_grammar)
     {
-        std::cout << "Creating Phonetic Corpus : tempFiles/corpus/phoneticCorpus.txt\n";
+        INFO << "Creating Phonetic Corpus : tempFiles/corpus/phoneticCorpus.txt";
 
         try
         {
@@ -108,7 +108,7 @@ void CreateBiasedLM(grammarName name, bool generateQuickLM) //Create biased lang
     int rv;
     if (name == lm || name == complete_grammar)
     {
-        std::cout << "Creating Biased Language Model : tempFiles/lm/complete.lm\n";
+        INFO << "Creating Biased Language Model : tempFiles/lm/complete.lm";
 
         if (generateQuickLM)
         {
@@ -182,8 +182,8 @@ void GenerateDict(bool generateQuickDict) // Generate dictionary from tensor flo
     }
     else
     {
-        std::cout << "Creating the Dictionary, this might take a little time depending "
-            "on your TensorFlow configuration : tempFiles/dict/complete.dict\n";
+        INFO << "Creating the Dictionary, this might take a little time depending "
+            "on your TensorFlow configuration : tempFiles/dict/complete.dict";
         int rv = systemGetStatus("g2p-seq2seq --decode tempFiles/vocab/complete.vocab --model g2p-seq2seq-cmudict/ > tempFiles/dict/complete.dict");
 
         if (rv != 0)
@@ -415,7 +415,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name) //Generat
 
     if (name == phone_lm || name == complete_grammar)
     {
-        std::cout << "Creating Phonetic Language Model : tempFiles/lm/phone.lm\n";
+        INFO << "Creating Phonetic Language Model : tempFiles/lm/phone.lm";
 
         rv = systemGetStatus("perl quick_lm.pl -s tempFiles/corpus/phoneticCorpus.txt 2>tempFiles/grammar.log");
         if (rv != 0)

--- a/src/lib_ccaligner/grammar_tools.cpp
+++ b/src/lib_ccaligner/grammar_tools.cpp
@@ -45,7 +45,7 @@ void CreateTempDirectories() // Create temporary directories
 
     if (rv != 0)
     {
-        FATAL(EXIT_FAILURE) << "Unable to create directory tempFiles/ : " << strerror(errno);
+        FATAL(UnknownError) << "Unable to create directory tempFiles/ : " << strerror(errno);
     }
 
     DEBUG << "Directories created successfully!";
@@ -69,7 +69,7 @@ void CreateNewGrammarFiles(grammarName name, std::ofstream &corpusDump, std::ofs
     }
     catch (std::system_error& e)
     {
-        FATAL(EXIT_FAILURE) << e.code().message();
+        FATAL(UnknownError) << e.code().message();
     }
 
     if (name == corpus || name == complete_grammar)
@@ -83,7 +83,7 @@ void CreateNewGrammarFiles(grammarName name, std::ofstream &corpusDump, std::ofs
         }
         catch (std::system_error& e)
         {
-            FATAL(EXIT_FAILURE) << e.code().message();
+            FATAL(UnknownError) << e.code().message();
         }
     }
 
@@ -98,7 +98,7 @@ void CreateNewGrammarFiles(grammarName name, std::ofstream &corpusDump, std::ofs
         }
         catch (std::system_error& e)
         {
-            FATAL(EXIT_FAILURE) << e.code().message();
+            FATAL(UnknownError) << e.code().message();
         }
     }
 }
@@ -115,7 +115,7 @@ void CreateBiasedLM(grammarName name, bool generateQuickLM) //Create biased lang
             rv = systemGetStatus("perl quick_lm.pl -s tempFiles/corpus/corpus.txt 2>tempFiles/grammar.log");
 
             if (rv != 0)
-                FATAL(EXIT_FAILURE) << "Something went wrong while creating Phonetic Language Model!";
+                FATAL(UnknownError) << "Something went wrong while creating Phonetic Language Model!";
 
 #ifndef WIN32
             rv = systemGetStatus("mv tempFiles/corpus/corpus.txt.arpabo tempFiles/lm/complete.lm 2>tempFiles/grammar.log");
@@ -123,19 +123,19 @@ void CreateBiasedLM(grammarName name, bool generateQuickLM) //Create biased lang
             rv = systemGetStatus("move tempFiles\\corpus\\corpus.txt.arpabo tempFiles\\lm\\complete.lm 2>tempFiles\\grammar.log");
 #endif
             if (rv != 0)
-                FATAL(EXIT_FAILURE) << "Something went wrong while moving phonetic model!";
+                FATAL(UnknownError) << "Something went wrong while moving phonetic model!";
         }
         else
         {
             rv = systemGetStatus("text2idngram -vocab tempFiles/vocab/complete.vocab -idngram tempFiles/lm/lm.idngram <  tempFiles/corpus/corpus.txt 2>tempFiles/grammar.log");
 
             if (rv != 0)
-                FATAL(EXIT_FAILURE) << "Something went wrong while creating idngram file!";
+                FATAL(UnknownError) << "Something went wrong while creating idngram file!";
 
             rv = systemGetStatus("idngram2lm -vocab_type 0 -idngram tempFiles/lm/lm.idngram -vocab tempFiles/vocab/complete.vocab  -arpa tempFiles/lm/complete.lm 2>tempFiles/grammar.log");
 
             if (rv != 0)
-                FATAL(EXIT_FAILURE) << "Something went wrong while creating biased language model!";
+                FATAL(UnknownError) << "Something went wrong while creating biased language model!";
         }
     }
 }
@@ -153,7 +153,7 @@ void GenerateDict(bool generateQuickDict) // Generate dictionary from tensor flo
         }
         catch (std::system_error& e)
         {
-            FATAL(EXIT_FAILURE) << e.code().message();
+            FATAL(UnknownError) << e.code().message();
         }
 
         std::string word;
@@ -188,7 +188,7 @@ void GenerateDict(bool generateQuickDict) // Generate dictionary from tensor flo
 
         if (rv != 0)
         {
-            FATAL(EXIT_FAILURE) << "Something went wrong while creating dictionary!";
+            FATAL(UnknownError) << "Something went wrong while creating dictionary!";
         }
     }
 
@@ -232,7 +232,7 @@ bool generate(std::string transcriptFileName, grammarName name) //Generate Gramm
         }
         catch (std::system_error& e)
         {
-            FATAL(EXIT_FAILURE) << e.code().message();
+            FATAL(UnknownError) << e.code().message();
         }
 
         corpusDump << "<s> " << stringToLower(transcript) << " </s>\n";
@@ -248,7 +248,7 @@ bool generate(std::string transcriptFileName, grammarName name) //Generate Gramm
 
         catch (std::system_error& e)
         {
-            FATAL(EXIT_FAILURE, e.code().message().c_str());
+            FATAL(UnknownError, e.code().message().c_str());
         }
 
         int numberOfWords = transcript.length();
@@ -275,7 +275,7 @@ bool generate(std::string transcriptFileName, grammarName name) //Generate Gramm
         rv = systemGetStatus("text2wfreq < tempFiles/corpus/corpus.txt 2>tempFiles/grammar.log | wfreq2vocab > tempFiles/vocab/complete.vocab 2>tempFiles/grammar_wfreq2vocab.log");
 
         if (rv != 0)
-            FATAL(EXIT_FAILURE) << "Something went wrong while creating vocabulary!";
+            FATAL(UnknownError) << "Something went wrong while creating vocabulary!";
     }
 
     if (name == dict || name == complete_grammar)
@@ -312,7 +312,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name) //Generat
             }
             catch(std::system_error& e)
             {
-                FATAL(EXIT_FAILURE) << e.code().message();
+                FATAL(UnknownError) << e.code().message();
             }
 
             corpusDump << "<s> " << stringToLower(sub->getDialogue()) << " </s>\n";
@@ -328,7 +328,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name) //Generat
 
             catch(std::system_error& e)
             {
-                FATAL(EXIT_FAILURE) << e.code().message();
+                FATAL(UnknownError) << e.code().message();
             }
 
             int numberOfWords = sub->getWordCount();
@@ -361,7 +361,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name) //Generat
 
             catch(std::system_error& e)
             {
-                FATAL(EXIT_FAILURE) << e.code().message();
+                FATAL(UnknownError) << e.code().message();
             }
 
             int numberOfWords = sub->getWordCount();
@@ -400,7 +400,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name) //Generat
 
         if (rv != 0)
         {
-            FATAL(EXIT_FAILURE) << "Something went wrong while creating vocabulary!";
+            FATAL(UnknownError) << "Something went wrong while creating vocabulary!";
         }
 
         DEBUG << "Vocabulary created!";
@@ -419,7 +419,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name) //Generat
 
         rv = systemGetStatus("perl quick_lm.pl -s tempFiles/corpus/phoneticCorpus.txt 2>tempFiles/grammar.log");
         if (rv != 0)
-            FATAL(EXIT_FAILURE) << "Something went wrong while creating Phonetic Language Model!";
+            FATAL(UnknownError) << "Something went wrong while creating Phonetic Language Model!";
 
 #ifndef WIN32
         rv = systemGetStatus("mv tempFiles/corpus/phoneticCorpus.txt.arpabo tempFiles/lm/ 2>tempFiles/grammar.log");
@@ -427,7 +427,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name) //Generat
         rv = systemGetStatus("move tempFiles\\corpus\\phoneticCorpus.txt.arpabo tempFiles\\lm\\ 2>tempFiles\\grammar.log");
 #endif
         if (rv != 0)
-            FATAL(EXIT_FAILURE) << "Something went wrong while moving phonetic model!";
+            FATAL(UnknownError) << "Something went wrong while moving phonetic model!";
     }
 
     DEBUG << "Grammar files created!";

--- a/src/lib_ccaligner/grammar_tools.cpp
+++ b/src/lib_ccaligner/grammar_tools.cpp
@@ -73,7 +73,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
     if(name == corpus || name == complete_grammar)
     {
-		debugstream << "Creating Corpus : tempFiles/corpus/corpus.txt";
+		infostream << "Creating Corpus : tempFiles/corpus/corpus.txt";
 
         try
         {
@@ -90,7 +90,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
     if(name == phone_lm || name == complete_grammar)
     {
-        debugstream << "Creating Phonetic Corpus : tempFiles/corpus/phoneticCorpus.txt";
+        infostream << "Creating Phonetic Corpus : tempFiles/corpus/phoneticCorpus.txt";
 
         try
         {
@@ -256,7 +256,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
         else
         {
-			debugstream << "Creating the Dictionary, this might take a little time depending "
+			infostream << "Creating the Dictionary, this might take a little time depending "
                 "on your TensorFlow configuration : tempFiles/dict/complete.dict";
 
             rv = systemGetStatus("g2p-seq2seq --decode tempFiles/vocab/complete.vocab --model g2p-seq2seq-cmudict/ > tempFiles/dict/complete.dict");
@@ -273,7 +273,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
     if(name == lm || name == complete_grammar )
     {
-        debugstream << "Creating Biased Language Model : tempFiles/lm/complete.lm";
+        infostream << "Creating Biased Language Model : tempFiles/lm/complete.lm";
 
         if(generateQuickLM)
         {
@@ -316,7 +316,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
     if(name == phone_lm  || name == complete_grammar )
     {
-        debugstream << "Creating Phonetic Language Model : tempFiles/lm/phone.lm";
+        infostream << "Creating Phonetic Language Model : tempFiles/lm/phone.lm";
 
         rv = systemGetStatus("perl quick_lm.pl -s tempFiles/corpus/phoneticCorpus.txt 2>tempFiles/grammar.log");
         if (rv != 0)

--- a/src/lib_ccaligner/grammar_tools.cpp
+++ b/src/lib_ccaligner/grammar_tools.cpp
@@ -35,7 +35,7 @@ void ConfigureQuickGenerationOptions(bool &generateQuickDict, bool &generateQuic
 void CreateTempDirectories() // Create temporary directories
 {
     //create temporary directories in case they don't exist
-    debugstream << "Creating temporary directories at tempFiles/";
+    DEBUG << "Creating temporary directories at tempFiles/";
 
 #ifndef WIN32
     int rv = systemGetStatus("mkdir -p tempFiles/corpus tempFiles/dict tempFiles/vocab tempFiles/fsg tempFiles/lm");
@@ -45,10 +45,10 @@ void CreateTempDirectories() // Create temporary directories
 
     if (rv != 0)
     {
-        fatalstream(EXIT_FAILURE) << "Unable to create directory tempFiles/ : " << strerror(errno);
+        FATAL(EXIT_FAILURE) << "Unable to create directory tempFiles/ : " << strerror(errno);
     }
 
-    debugstream << "Directories created successfully!";
+    DEBUG << "Directories created successfully!";
 }
 
 void CreateNewGrammarFiles(grammarName name, std::ofstream &corpusDump, std::ofstream &fsgDump,
@@ -69,7 +69,7 @@ void CreateNewGrammarFiles(grammarName name, std::ofstream &corpusDump, std::ofs
     }
     catch (std::system_error& e)
     {
-        fatalstream(EXIT_FAILURE) << e.code().message();
+        FATAL(EXIT_FAILURE) << e.code().message();
     }
 
     if (name == corpus || name == complete_grammar)
@@ -83,7 +83,7 @@ void CreateNewGrammarFiles(grammarName name, std::ofstream &corpusDump, std::ofs
         }
         catch (std::system_error& e)
         {
-            fatalstream(EXIT_FAILURE) << e.code().message();
+            FATAL(EXIT_FAILURE) << e.code().message();
         }
     }
 
@@ -98,7 +98,7 @@ void CreateNewGrammarFiles(grammarName name, std::ofstream &corpusDump, std::ofs
         }
         catch (std::system_error& e)
         {
-            fatalstream(EXIT_FAILURE) << e.code().message();
+            FATAL(EXIT_FAILURE) << e.code().message();
         }
     }
 }
@@ -115,7 +115,7 @@ void CreateBiasedLM(grammarName name, bool generateQuickLM) //Create biased lang
             rv = systemGetStatus("perl quick_lm.pl -s tempFiles/corpus/corpus.txt 2>tempFiles/grammar.log");
 
             if (rv != 0)
-                fatalstream(EXIT_FAILURE) << "Something went wrong while creating Phonetic Language Model!";
+                FATAL(EXIT_FAILURE) << "Something went wrong while creating Phonetic Language Model!";
 
 #ifndef WIN32
             rv = systemGetStatus("mv tempFiles/corpus/corpus.txt.arpabo tempFiles/lm/complete.lm 2>tempFiles/grammar.log");
@@ -123,19 +123,19 @@ void CreateBiasedLM(grammarName name, bool generateQuickLM) //Create biased lang
             rv = systemGetStatus("move tempFiles\\corpus\\corpus.txt.arpabo tempFiles\\lm\\complete.lm 2>tempFiles\\grammar.log");
 #endif
             if (rv != 0)
-                fatalstream(EXIT_FAILURE) << "Something went wrong while moving phonetic model!";
+                FATAL(EXIT_FAILURE) << "Something went wrong while moving phonetic model!";
         }
         else
         {
             rv = systemGetStatus("text2idngram -vocab tempFiles/vocab/complete.vocab -idngram tempFiles/lm/lm.idngram <  tempFiles/corpus/corpus.txt 2>tempFiles/grammar.log");
 
             if (rv != 0)
-                fatalstream(EXIT_FAILURE) << "Something went wrong while creating idngram file!";
+                FATAL(EXIT_FAILURE) << "Something went wrong while creating idngram file!";
 
             rv = systemGetStatus("idngram2lm -vocab_type 0 -idngram tempFiles/lm/lm.idngram -vocab tempFiles/vocab/complete.vocab  -arpa tempFiles/lm/complete.lm 2>tempFiles/grammar.log");
 
             if (rv != 0)
-                fatalstream(EXIT_FAILURE) << "Something went wrong while creating biased language model!";
+                FATAL(EXIT_FAILURE) << "Something went wrong while creating biased language model!";
         }
     }
 }
@@ -153,7 +153,7 @@ void GenerateDict(bool generateQuickDict) // Generate dictionary from tensor flo
         }
         catch (std::system_error& e)
         {
-            fatalstream(EXIT_FAILURE) << e.code().message();
+            FATAL(EXIT_FAILURE) << e.code().message();
         }
 
         std::string word;
@@ -188,7 +188,7 @@ void GenerateDict(bool generateQuickDict) // Generate dictionary from tensor flo
 
         if (rv != 0)
         {
-            fatalstream(EXIT_FAILURE) << "Something went wrong while creating dictionary!";
+            FATAL(EXIT_FAILURE) << "Something went wrong while creating dictionary!";
         }
     }
 
@@ -232,7 +232,7 @@ bool generate(std::string transcriptFileName, grammarName name) //Generate Gramm
         }
         catch (std::system_error& e)
         {
-            fatalstream(EXIT_FAILURE) << e.code().message();
+            FATAL(EXIT_FAILURE) << e.code().message();
         }
 
         corpusDump << "<s> " << stringToLower(transcript) << " </s>\n";
@@ -275,7 +275,7 @@ bool generate(std::string transcriptFileName, grammarName name) //Generate Gramm
         rv = systemGetStatus("text2wfreq < tempFiles/corpus/corpus.txt 2>tempFiles/grammar.log | wfreq2vocab > tempFiles/vocab/complete.vocab 2>tempFiles/grammar_wfreq2vocab.log");
 
         if (rv != 0)
-            fatalstream(EXIT_FAILURE) << "Something went wrong while creating vocabulary!";
+            FATAL(EXIT_FAILURE) << "Something went wrong while creating vocabulary!";
     }
 
     if (name == dict || name == complete_grammar)
@@ -285,7 +285,7 @@ bool generate(std::string transcriptFileName, grammarName name) //Generate Gramm
 
     CreateBiasedLM(name, generateQuickLM);
 
-    debugstream<<"Grammar files created!";
+    DEBUG<<"Grammar files created!";
     return true;
 }
 
@@ -312,7 +312,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name) //Generat
             }
             catch(std::system_error& e)
             {
-                fatalstream(EXIT_FAILURE) << e.code().message();
+                FATAL(EXIT_FAILURE) << e.code().message();
             }
 
             corpusDump << "<s> " << stringToLower(sub->getDialogue()) << " </s>\n";
@@ -328,7 +328,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name) //Generat
 
             catch(std::system_error& e)
             {
-                fatalstream(EXIT_FAILURE) << e.code().message();
+                FATAL(EXIT_FAILURE) << e.code().message();
             }
 
             int numberOfWords = sub->getWordCount();
@@ -361,7 +361,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name) //Generat
 
             catch(std::system_error& e)
             {
-                fatalstream(EXIT_FAILURE) << e.code().message();
+                FATAL(EXIT_FAILURE) << e.code().message();
             }
 
             int numberOfWords = sub->getWordCount();
@@ -394,16 +394,16 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name) //Generat
 
     if(name == vocab || name == complete_grammar)
     {
-        debugstream << "Creating vocabulary...";
+        DEBUG << "Creating vocabulary...";
 
         rv = systemGetStatus("text2wfreq < tempFiles/corpus/corpus.txt 2>tempFiles/grammar.log | wfreq2vocab > tempFiles/vocab/complete.vocab 2>tempFiles/grammar_wfreq2vocab.log");
 
         if (rv != 0)
         {
-            fatalstream(EXIT_FAILURE) << "Something went wrong while creating vocabulary!";
+            FATAL(EXIT_FAILURE) << "Something went wrong while creating vocabulary!";
         }
 
-        debugstream << "Vocabulary created!";
+        DEBUG << "Vocabulary created!";
     }
 
     if(name == dict || name == complete_grammar)
@@ -419,7 +419,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name) //Generat
 
         rv = systemGetStatus("perl quick_lm.pl -s tempFiles/corpus/phoneticCorpus.txt 2>tempFiles/grammar.log");
         if (rv != 0)
-            fatalstream(EXIT_FAILURE) << "Something went wrong while creating Phonetic Language Model!";
+            FATAL(EXIT_FAILURE) << "Something went wrong while creating Phonetic Language Model!";
 
 #ifndef WIN32
         rv = systemGetStatus("mv tempFiles/corpus/phoneticCorpus.txt.arpabo tempFiles/lm/ 2>tempFiles/grammar.log");
@@ -427,10 +427,10 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name) //Generat
         rv = systemGetStatus("move tempFiles\\corpus\\phoneticCorpus.txt.arpabo tempFiles\\lm\\ 2>tempFiles\\grammar.log");
 #endif
         if (rv != 0)
-            fatalstream(EXIT_FAILURE) << "Something went wrong while moving phonetic model!";
+            FATAL(EXIT_FAILURE) << "Something went wrong while moving phonetic model!";
     }
 
-    debugstream << "Grammar files created!";
+    DEBUG << "Grammar files created!";
 
     return true;
 }

--- a/src/lib_ccaligner/grammar_tools.cpp
+++ b/src/lib_ccaligner/grammar_tools.cpp
@@ -73,7 +73,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
     if(name == corpus || name == complete_grammar)
     {
-        std::cout<<"Creating Corpus : tempFiles/corpus/corpus.txt\n";
+		LOG("Creating Corpus : tempFiles/corpus/corpus.txt");
 
         try
         {
@@ -90,7 +90,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
     if(name == phone_lm || name == complete_grammar)
     {
-        std::cout<<"Creating Phonetic Corpus : tempFiles/corpus/phoneticCorpus.txt\n";
+        LOG("Creating Phonetic Corpus : tempFiles/corpus/phoneticCorpus.txt");
 
         try
         {
@@ -200,12 +200,16 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
     if(name == vocab || name == complete_grammar)
     {
+		LOG("Creating vocabulary...");
+
         rv = systemGetStatus("text2wfreq < tempFiles/corpus/corpus.txt 2>tempFiles/grammar.log | wfreq2vocab > tempFiles/vocab/complete.vocab 2>tempFiles/grammar_wfreq2vocab.log");
 
         if (rv != 0)
         {
             FATAL(EXIT_FAILURE, "Something went wrong while creating vocabulary!");
         }
+
+		LOG("Vocabulary created!");
     }
 
     if(name == dict || name == complete_grammar)
@@ -252,21 +256,24 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
         else
         {
-            std::cout<<"Creating the Dictionary, this might take a little time depending "
-                "on your TensorFlow configuration : tempFiles/dict/complete.dict\n";
+			LOG("Creating the Dictionary, this might take a little time depending "
+                "on your TensorFlow configuration : tempFiles/dict/complete.dict");
+
             rv = systemGetStatus("g2p-seq2seq --decode tempFiles/vocab/complete.vocab --model g2p-seq2seq-cmudict/ > tempFiles/dict/complete.dict");
 
             if (rv != 0)
             {
                 FATAL(EXIT_FAILURE, "Something went wrong while creating dictionary!");
             }
+
+			LOG("Dictionary created");
         }
 
     }
 
     if(name == lm || name == complete_grammar )
     {
-        std::cout<<"Creating Biased Language Model : tempFiles/lm/complete.lm\n";
+        LOG("Creating Biased Language Model : tempFiles/lm/complete.lm");
 
         if(generateQuickLM)
         {
@@ -303,13 +310,13 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
                 FATAL(EXIT_FAILURE, "Something went wrong while creating biased language model!");
             }
         }
-
+		LOG("Biased Language Model created successfully!");
 
     }
 
     if(name == phone_lm  || name == complete_grammar )
     {
-        std::cout<<"Creating Phonetic Language Model : tempFiles/lm/phone.lm\n";
+        LOG("Creating Phonetic Language Model : tempFiles/lm/phone.lm");
 
         rv = systemGetStatus("perl quick_lm.pl -s tempFiles/corpus/phoneticCorpus.txt 2>tempFiles/grammar.log");
         if (rv != 0)

--- a/src/lib_ccaligner/grammar_tools.cpp
+++ b/src/lib_ccaligner/grammar_tools.cpp
@@ -34,7 +34,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
     }
 
     //create temporary directories in case they don't exist
-    LOG("Creating temporary directories at tempFiles/");
+    debugstream << "Creating temporary directories at tempFiles/";
 
 #ifndef WIN32
     int rv = systemGetStatus("mkdir -p tempFiles/corpus tempFiles/dict tempFiles/vocab tempFiles/fsg tempFiles/lm");
@@ -44,11 +44,11 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
   
     if (rv != 0)
     {
-        FATAL(EXIT_FAILURE, "Unable to create directory tempFiles/ : %s", strerror(errno));
+        fatalstream(EXIT_FAILURE) << "Unable to create directory tempFiles/ : " << strerror(errno);
     }
 
 
-    LOG("Directories created successfully!");
+    debugstream << "Directories created successfully!";
 
     std::ofstream corpusDump, phoneticCorpusDump, fsgDump, vocabDump, dictDump, logDump;
 
@@ -68,12 +68,12 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
     catch(std::system_error& e)
     {
-        FATAL(EXIT_FAILURE, e.code().message().c_str());
+        fatalstream(EXIT_FAILURE) << e.code().message();
     }
 
     if(name == corpus || name == complete_grammar)
     {
-		LOG("Creating Corpus : tempFiles/corpus/corpus.txt");
+		debugstream << "Creating Corpus : tempFiles/corpus/corpus.txt";
 
         try
         {
@@ -83,14 +83,14 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
         catch(std::system_error& e)
         {
-            FATAL(EXIT_FAILURE, e.code().message().c_str());
+            fatalstream(EXIT_FAILURE) << e.code().message();
         }
 
     }
 
     if(name == phone_lm || name == complete_grammar)
     {
-        LOG("Creating Phonetic Corpus : tempFiles/corpus/phoneticCorpus.txt");
+        debugstream << "Creating Phonetic Corpus : tempFiles/corpus/phoneticCorpus.txt";
 
         try
         {
@@ -100,7 +100,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
         catch(std::system_error& e)
         {
-            FATAL(EXIT_FAILURE, e.code().message().c_str());
+            fatalstream(EXIT_FAILURE) << e.code().message();
         }
 
     }
@@ -116,7 +116,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
             catch(std::system_error& e)
             {
-                FATAL(EXIT_FAILURE, e.code().message().c_str());
+                fatalstream(EXIT_FAILURE) << e.code().message();
             }
 
             corpusDump << "<s> " << stringToLower(sub->getDialogue()) << " </s>\n";
@@ -132,7 +132,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
             catch(std::system_error& e)
             {
-                FATAL(EXIT_FAILURE, e.code().message().c_str());
+                fatalstream(EXIT_FAILURE) << e.code().message();
             }
 
             int numberOfWords = sub->getWordCount();
@@ -165,7 +165,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
             catch(std::system_error& e)
             {
-                FATAL(EXIT_FAILURE, e.code().message().c_str());
+                fatalstream(EXIT_FAILURE) << e.code().message().c_str();
             }
 
             int numberOfWords = sub->getWordCount();
@@ -200,16 +200,16 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
     if(name == vocab || name == complete_grammar)
     {
-		LOG("Creating vocabulary...");
+		debugstream << "Creating vocabulary...";
 
         rv = systemGetStatus("text2wfreq < tempFiles/corpus/corpus.txt 2>tempFiles/grammar.log | wfreq2vocab > tempFiles/vocab/complete.vocab 2>tempFiles/grammar_wfreq2vocab.log");
 
         if (rv != 0)
         {
-            FATAL(EXIT_FAILURE, "Something went wrong while creating vocabulary!");
+            fatalstream(EXIT_FAILURE) << "Something went wrong while creating vocabulary!";
         }
 
-		LOG("Vocabulary created!");
+		debugstream << "Vocabulary created!";
     }
 
     if(name == dict || name == complete_grammar)
@@ -225,7 +225,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
             catch(std::system_error& e)
             {
-                FATAL(EXIT_FAILURE, e.code().message().c_str());
+                fatalstream(EXIT_FAILURE) << e.code().message();
             }
 
             std::string word;
@@ -256,31 +256,31 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
         else
         {
-			LOG("Creating the Dictionary, this might take a little time depending "
-                "on your TensorFlow configuration : tempFiles/dict/complete.dict");
+			debugstream << "Creating the Dictionary, this might take a little time depending "
+                "on your TensorFlow configuration : tempFiles/dict/complete.dict";
 
             rv = systemGetStatus("g2p-seq2seq --decode tempFiles/vocab/complete.vocab --model g2p-seq2seq-cmudict/ > tempFiles/dict/complete.dict");
 
             if (rv != 0)
             {
-                FATAL(EXIT_FAILURE, "Something went wrong while creating dictionary!");
+                fatalstream(EXIT_FAILURE) << "Something went wrong while creating dictionary!";
             }
 
-			LOG("Dictionary created");
+			debugstream << "Dictionary created";
         }
 
     }
 
     if(name == lm || name == complete_grammar )
     {
-        LOG("Creating Biased Language Model : tempFiles/lm/complete.lm");
+        debugstream << "Creating Biased Language Model : tempFiles/lm/complete.lm";
 
         if(generateQuickLM)
         {
             rv = systemGetStatus("perl quick_lm.pl -s tempFiles/corpus/corpus.txt 2>tempFiles/grammar.log");
             if (rv != 0)
             {
-                FATAL(EXIT_FAILURE, "Something went wrong while creating Phonetic Language Model!");
+                fatalstream(EXIT_FAILURE) << "Something went wrong while creating Phonetic Language Model!";
             }
 #ifndef WIN32
             rv = systemGetStatus("mv tempFiles/corpus/corpus.txt.arpabo tempFiles/lm/complete.lm 2>tempFiles/grammar.log");
@@ -290,7 +290,7 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
             if (rv != 0)
             {
-                FATAL(EXIT_FAILURE, "Something went wrong while moving phonetic model!");
+                fatalstream(EXIT_FAILURE) << "Something went wrong while moving phonetic model!";
             }
         }
 
@@ -300,28 +300,28 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 
             if (rv != 0)
             {
-                FATAL(EXIT_FAILURE, "Something went wrong while creating idngram file!");
+                fatalstream(EXIT_FAILURE) << "Something went wrong while creating idngram file!";
             }
 
             rv = systemGetStatus("idngram2lm -vocab_type 0 -idngram tempFiles/lm/lm.idngram -vocab tempFiles/vocab/complete.vocab  -arpa tempFiles/lm/complete.lm 2>tempFiles/grammar.log");
 
             if (rv != 0)
             {
-                FATAL(EXIT_FAILURE, "Something went wrong while creating biased language model!");
+                fatalstream(EXIT_FAILURE) << "Something went wrong while creating biased language model!";
             }
         }
-		LOG("Biased Language Model created successfully!");
+		debugstream << "Biased Language Model created successfully!";
 
     }
 
     if(name == phone_lm  || name == complete_grammar )
     {
-        LOG("Creating Phonetic Language Model : tempFiles/lm/phone.lm");
+        debugstream << "Creating Phonetic Language Model : tempFiles/lm/phone.lm";
 
         rv = systemGetStatus("perl quick_lm.pl -s tempFiles/corpus/phoneticCorpus.txt 2>tempFiles/grammar.log");
         if (rv != 0)
         {
-            FATAL(EXIT_FAILURE, "Something went wrong while creating Phonetic Language Model!");
+            fatalstream(EXIT_FAILURE) << "Something went wrong while creating Phonetic Language Model!";
         }
 #ifndef WIN32
         rv = systemGetStatus("mv tempFiles/corpus/phoneticCorpus.txt.arpabo tempFiles/lm/ 2>tempFiles/grammar.log");
@@ -330,11 +330,11 @@ bool generate(std::vector <SubtitleItem*> subtitles, grammarName name)
 #endif
         if (rv != 0)
         {
-            FATAL(EXIT_FAILURE, "Something went wrong while moving phonetic model!");
+            fatalstream(EXIT_FAILURE) << "Something went wrong while moving phonetic model!";
         }
     }
 
-    LOG("Grammar files created!");
+    debugstream << "Grammar files created!";
 
     return true;
 

--- a/src/lib_ccaligner/logger.cpp
+++ b/src/lib_ccaligner/logger.cpp
@@ -1,0 +1,14 @@
+/*
+* Author   : Harry Yu
+* Email    : harryyunull@gmail.com
+* Link     : https://github.com/harrynull
+*/
+#include "logger.h"
+
+std::array<const char*, 6> Logger::levelTags{
+    "[verbose]", "[debug]", "[info]", "[warning]", "[error]", "[fatal]"
+};
+
+std::array<Colors::ColorFunc*, 6> Logger::colors{
+    Colors::white, Colors::white, Colors::lwhite, Colors::yellow, Colors::lred, Colors::red
+};

--- a/src/lib_ccaligner/logger.cpp
+++ b/src/lib_ccaligner/logger.cpp
@@ -6,7 +6,7 @@
 #include "logger.h"
 
 std::array<const char*, 6> Logger::levelTags{
-    "[verbose]", "[debug]", "[info]", "[warning]", "[error]", "[fatal]"
+    "[Verbose]", "[Debug]", "[Info]", "[Warning]", "[Error]", "[Fatal]"
 };
 
 std::array<Colors::ColorFunc*, 6> Logger::colors{

--- a/src/lib_ccaligner/logger.h
+++ b/src/lib_ccaligner/logger.h
@@ -169,16 +169,16 @@ inline Logger& getLogger() {
 
 #define loggerstream(level) (Logger::Log(getLogger(), __FILE__, __FUNCTION__, __LINE__, Logger::Level::level, Logger::levelTags[Logger::Level::level]))
 // Information for tracing
-#define verbosestream loggerstream(verbose)
+#define VERBOSE loggerstream(verbose)
 // Information for developers
-#define debugstream loggerstream(debug)
+#define DEBUG loggerstream(debug)
 // Information for general users
-#define infostream loggerstream(info)
+#define INFO loggerstream(info)
 // Problems that may affect facility, performance or stability but may not lead the program to crash immediately
-#define warningstream loggerstream(warning)
+#define WARNING loggerstream(warning)
 // Something unexpected happened but can be recovered
-#define errorstream loggerstream(error)
+#define ERROR loggerstream(error)
 // Unrecoverable error and program termination is required
-#define fatalstream(code) (Logger::Log(getLogger(), __FILE__, __FUNCTION__, __LINE__, Logger::Level::fatal, Logger::levelTags[Logger::Level::fatal], code))
+#define FATAL(code) (Logger::Log(getLogger(), __FILE__, __FUNCTION__, __LINE__, Logger::Level::fatal, Logger::levelTags[Logger::Level::fatal], code))
 
 #endif

--- a/src/lib_ccaligner/logger.h
+++ b/src/lib_ccaligner/logger.h
@@ -1,0 +1,161 @@
+/*
+* Author   : Harry Yu
+* Email    : harryyunull@gmail.com
+* Link     : https://github.com/harrynull
+*/
+
+#ifndef CCALIGNER_LOGGER_H
+#define CCALIGNER_LOGGER_H
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <ctime>
+#include <array>
+
+// Define possible exit codes that will be passed on to the fatal function exit codes.
+#define DO_NOT_EXIT                             -1
+#define EXIT_OK                                 0
+#define EXIT_FILE_NOT_FOUND                     2
+#define EXIT_INVALID_PARAMETERS                 3
+#define EXIT_INCOMPATIBLE_PARAMETERS            4
+#define EXIT_INCOMPLETE_PARAMETERS              5
+#define EXIT_INVALID_FILE                       6
+#define EXIT_WITH_HELP                          10
+#define EXIT_UNKNOWN                            13
+
+namespace Colors {
+    using ColorFunc = std::ostream&(std::ostream&);
+#ifdef WIN32
+#define NOMINMAX
+#include <Windows.h>
+#define WINDOWS_COLOR(colorName, colorCode)\
+    inline std::ostream& colorName(std::ostream& s)\
+    {SetConsoleTextAttribute(hStdout, colorCode);return s;}
+
+    static HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
+
+    WINDOWS_COLOR(red,      FOREGROUND_RED);
+    WINDOWS_COLOR(yellow,   FOREGROUND_RED | FOREGROUND_GREEN);
+    WINDOWS_COLOR(lred,     FOREGROUND_RED | FOREGROUND_INTENSITY);
+    WINDOWS_COLOR(white,    FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE);
+    WINDOWS_COLOR(lyellow,  FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY);
+    WINDOWS_COLOR(lwhite,   FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+#undef WINDOWS_COLOR
+
+#else
+#define LINUX_COLOR(colorName, colorCode) inline std::ostream& colorName(std::ostream &s) {return s << colorCode;}
+
+    LINUX_COLOR(red,        "\033[21;31m");
+    LINUX_COLOR(yellow,     "\033[21;33m");
+    LINUX_COLOR(lred,       "\033[1;31m");
+    LINUX_COLOR(white,      "\033[21;37m");
+    LINUX_COLOR(lyellow,    "\033[1;33m");
+    LINUX_COLOR(lwhite,     "\033[1;37m");
+
+#undef LINUX_COLOR
+#endif
+}
+
+class Logger {
+public:
+
+    enum Level {
+        verbose, debug, info, warning, error, fatal, nolog
+    };
+
+    static std::array<const char*, 6> levelTags;
+    static std::array<Colors::ColorFunc*, 6> colors;
+
+    // A sink -- where the log will go to. It can be stdout, a file, or any custom ostream (like network).
+    class Sink {
+    public:
+        Sink(std::ostream& os, bool useColor) :_os(os), _useColor(useColor) {}
+        
+        // Write stringstream to ostream if the level is higher than the minimum output level.
+        void output(std::stringstream& ss, Level level) const {
+            if (level < _minimumOutputLevel) return;
+            if (_useColor) _os << *colors[level];
+            _os << ss.rdbuf();
+            if (level == error || level == fatal) ss.flush(); // flush immediately to prevent data loss.
+        }
+
+        // Set thte minimum output level.
+        void setMinimumOutputLevel(Level level) noexcept {
+            _minimumOutputLevel = level;
+        }
+
+    private:
+        std::ostream& _os;
+        Level _minimumOutputLevel = Level::verbose;
+        bool _useColor;
+    };
+
+    class Log {
+    public:
+        Log(const Logger& logger, const char* fileName, const char* funcName, int lineNumber, Level level, const char* levelName, int exitCode = DO_NOT_EXIT)
+            :_logger(logger), _level(level), _exitCode(exitCode) {
+            _ss << "[" << getCurrentTime() << "]" << levelName << fileName << " : " << funcName << " | ";
+        }
+        
+        ~Log() {
+            _logger.log(_ss, _level);
+            if (_exitCode != DO_NOT_EXIT) std::exit(_exitCode);
+        }
+
+        template <typename T>
+        Log& operator<<(const T& rhs) {
+            _ss << rhs;
+            return *this;
+        }
+
+    private:
+        static std::string getCurrentTime() {
+            std::string currentTime(15, '\0');
+            const auto now = std::time(nullptr);
+            std::strftime(&currentTime.front(), currentTime.size(), "%m-%d %H:%M:%S", std::localtime(&now));
+            return currentTime;
+        }
+
+        const Logger& _logger;
+        std::stringstream _ss;
+        Level _level;
+        int _exitCode;
+    };
+
+    // It will apply the level to all **existing** sinks. Set level to nolog if you don't want any log.
+    void setMinimumOutputLevel(Level level) noexcept {
+        for (auto& sink : _sinks) sink.setMinimumOutputLevel(level);
+    }
+
+    void log(std::stringstream& ss, Level level) const {
+        for (auto& sink : _sinks) sink.output(ss, level);
+    }
+
+    friend Logger& getLogger();
+
+private:
+    Logger() : _sinks{ {std::cout, true} } {}
+    std::vector<Sink> _sinks;
+};
+
+inline Logger& getLogger() {
+    static Logger logger;
+    return logger;
+}
+
+#define loggerstream(level) (Logger::Log(getLogger(), __FILE__, __FUNCTION__, __LINE__, Logger::Level::level, Logger::levelTags[Logger::Level::level]))
+// Information for tracing
+#define verbosestream loggerstream(verbose)
+// Information for developers
+#define debugstream loggerstream(debug)
+// Information for general users
+#define infostream loggerstream(info)
+// Problems that may affect facility, performance or stability but may not lead the program to crash immediately
+#define warningstream loggerstream(warning)
+// Something unexpected happened but can be recovered
+#define errorstream loggerstream(error)
+// Unrecoverable error and program termination is required
+#define fatalstream(code) (Logger::Log(getLogger(), __FILE__, __FUNCTION__, __LINE__, Logger::Level::fatal, Logger::levelTags[Logger::Level::fatal], code))
+
+#endif

--- a/src/lib_ccaligner/logger.h
+++ b/src/lib_ccaligner/logger.h
@@ -99,6 +99,7 @@ public:
         }
         
         ~Log() {
+            _ss << std::endl;
             _logger.log(_ss, _level);
             if (_exitCode != DO_NOT_EXIT) std::exit(_exitCode);
         }

--- a/src/lib_ccaligner/logger.h
+++ b/src/lib_ccaligner/logger.h
@@ -146,9 +146,9 @@ public:
 
     private:
         template<class E = ExceptionType>
-        typename std::enable_if<std::is_same_v<E, Dummy>>::type throwExceptionIfNeeded() {}
+        typename std::enable_if<std::is_same<E, Dummy>::value>::type throwExceptionIfNeeded() {}
         template<class E = ExceptionType>
-        typename std::enable_if<!std::is_same_v<E, Dummy>>::type throwExceptionIfNeeded() noexcept(false) {
+        typename std::enable_if<!std::is_same<E, Dummy>::value>::type throwExceptionIfNeeded() noexcept(false) {
             throw E(_ss.str());
         }
 

--- a/src/lib_ccaligner/logger.h
+++ b/src/lib_ccaligner/logger.h
@@ -13,6 +13,7 @@
 #include <ctime>
 #include <array>
 #include <exception>
+#include <typeinfo>
 
 // Define possible exit codes that will be passed on to the fatal function exit codes.
 struct Dummy {};

--- a/src/lib_ccaligner/params.cpp
+++ b/src/lib_ccaligner/params.cpp
@@ -564,7 +564,7 @@ void Params::validateParams()
 
     if(verbosity)
     {
-        should_log = true;
+        //should_log = true;
         printParams();
     }
 }

--- a/src/lib_ccaligner/params.cpp
+++ b/src/lib_ccaligner/params.cpp
@@ -64,7 +64,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         if (paramPrefix == "-wav") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-wav requires a path to valid wave!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-wav requires a path to valid wave!";
             }
 
             audioFileName = subParam;
@@ -72,7 +72,7 @@ void Params::inputParams(int argc, char *argv[]) {
         }
         else if (paramPrefix == "-raw") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-raw requires a path to valid raw wave!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-raw requires a path to valid raw wave!";
             }
 
             audioFileName = subParam;
@@ -85,7 +85,7 @@ void Params::inputParams(int argc, char *argv[]) {
         }
         else if (paramPrefix == "-srt") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-srt requires a path to valid SubRip subtitle file!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-srt requires a path to valid SubRip subtitle file!";
             }
 
             usingTranscript = false;
@@ -94,7 +94,7 @@ void Params::inputParams(int argc, char *argv[]) {
         }
         else if (paramPrefix == "-txt") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-txt requires a path to valid transcript file!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-txt requires a path to valid transcript file!";
             }
 
             usingTranscript = true;
@@ -107,7 +107,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-out") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-out requires a valid output filename!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-out requires a valid output filename!";
             }
 
             outputFileName = subParam;
@@ -116,7 +116,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-oFormat") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-oFormat requires a valid output format";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-oFormat requires a valid output format";
             }
 
             if (subParam == "srt")
@@ -135,7 +135,7 @@ void Params::inputParams(int argc, char *argv[]) {
                 outputFormat = console;
 
             else {
-                fatalstream(EXIT_INVALID_PARAMETERS) << "-oFormat requires a valid output format!";
+                FATAL(EXIT_INVALID_PARAMETERS) << "-oFormat requires a valid output format!";
             }
 
             i++;
@@ -143,7 +143,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-model") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-model requires a path to valid acoustic model!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-model requires a path to valid acoustic model!";
             }
 
             modelPath = subParam;
@@ -152,7 +152,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-lm") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-lm requires a path to language model!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-lm requires a path to language model!";
             }
 
             lmPath = subParam;
@@ -162,7 +162,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-dict") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-dict requires a path to a valid dictionary file!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-dict requires a path to a valid dictionary file!";
             }
 
             dictPath = subParam;
@@ -172,7 +172,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-fsg") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-fsg requires a path to a valid directory containing FSG files!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-fsg requires a path to a valid directory containing FSG files!";
             }
 
             fsgPath = subParam;
@@ -182,7 +182,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-log") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-log requires a path to a valid output log file!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-log requires a path to a valid output log file!";
             }
 
             logPath = subParam;
@@ -191,7 +191,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-phoneLM") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-phoneLM requires a path to a valid phonetic language model!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-phoneLM requires a path to a valid phonetic language model!";
 
             }
 
@@ -201,7 +201,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-alignerLog") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-alignerLog requires a path to a valid output log file!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-alignerLog requires a path to a valid output log file!";
 
             }
 
@@ -211,7 +211,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-phoneLog") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-phoneLog requires a path to a valid output log file!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-phoneLog requires a path to a valid output log file!";
 
             }
 
@@ -221,7 +221,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "--enable-phonemes") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "--enable-phonemes requires a valid response!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "--enable-phonemes requires a valid response!";
 
             }
 
@@ -233,7 +233,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "--generate-grammar") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "--generate-grammar requires a valid response!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "--generate-grammar requires a valid response!";
 
             }
 
@@ -259,7 +259,7 @@ void Params::inputParams(int argc, char *argv[]) {
                 grammarType = vocab;
 
             else {
-                fatalstream(EXIT_INVALID_PARAMETERS) << "--generate-grammar requires a valid response!";
+                FATAL(EXIT_INVALID_PARAMETERS) << "--generate-grammar requires a valid response!";
             }
 
             i++;
@@ -267,7 +267,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "--quick-dict") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "--quick-dict requires a valid response!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "--quick-dict requires a valid response!";
             }
 
             if (subParam == "yes")
@@ -278,7 +278,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "--quick-lm") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "--quick-lm requires a valid response!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "--quick-lm requires a valid response!";
             }
 
             if (subParam == "yes")
@@ -289,7 +289,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "--print-aligned") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "--print-aligned requires a valid response!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "--print-aligned requires a valid response!";
             }
 
             if (subParam == "yes")
@@ -308,7 +308,7 @@ void Params::inputParams(int argc, char *argv[]) {
                 printOption = printAsKaraoke;
 
             else {
-                fatalstream(EXIT_INVALID_PARAMETERS) << "--print-aligned requires a valid response!";
+                FATAL(EXIT_INVALID_PARAMETERS) << "--print-aligned requires a valid response!";
             }
 
             i++;
@@ -316,7 +316,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "--use-fsg") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "--use-fsg requires a valid response!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "--use-fsg requires a valid response!";
             }
 
             if (subParam == "yes")
@@ -327,7 +327,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-transcribe") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-transcribe requires a valid response!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-transcribe requires a valid response!";
             }
 
             if (subParam == "yes")
@@ -339,7 +339,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-verbosity") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-verbose requires a valid response!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-verbose requires a valid response!";
             }
 
             if (subParam == "verbose")
@@ -360,7 +360,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "--display-recognised") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "--display-recognised requires a valid response!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "--display-recognised requires a valid response!";
             }
 
             if (subParam == "no")
@@ -371,13 +371,13 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-searchWindow") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-searchWindow requires an integer value to determine the search scope!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-searchWindow requires an integer value to determine the search scope!";
             }
 
             searchWindow = std::strtoul(subParam.c_str(), nullptr, 10);
 
             if (errno) {
-                fatalstream(EXIT_FAILURE) << "Invalid value passed to -searchWindow : " << strerror(errno);
+                FATAL(EXIT_FAILURE) << "Invalid value passed to -searchWindow : " << strerror(errno);
             }
 
             i++;
@@ -385,13 +385,13 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-sampleWindow") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-sampleWindow requires a valid integer value to determine the recognition scope!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-sampleWindow requires a valid integer value to determine the recognition scope!";
             }
 
             sampleWindow = std::strtoul(subParam.c_str(), nullptr, 10);
 
             if (errno) {
-                fatalstream(EXIT_FAILURE) << "Invalid value passed to -sampleWindow : " << strerror(errno);
+                FATAL(EXIT_FAILURE) << "Invalid value passed to -sampleWindow : " << strerror(errno);
             }
 
             i++;
@@ -399,13 +399,13 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-audioWindow") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-audioWindow requires a valid integer value in milliseconds to determine the recognition scope!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-audioWindow requires a valid integer value in milliseconds to determine the recognition scope!";
             }
 
             audioWindow = std::strtoul(subParam.c_str(), nullptr, 10);
 
             if (errno) {
-                fatalstream(EXIT_FAILURE) << "Invalid value passed to -audioWindow : " << strerror(errno);
+                FATAL(EXIT_FAILURE) << "Invalid value passed to -audioWindow : " << strerror(errno);
             }
 
             i++;
@@ -413,7 +413,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-useBatchMode") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-useBatchMode requires a valid response!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-useBatchMode requires a valid response!";
             }
 
             if (subParam == "yes")
@@ -424,7 +424,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-experiment") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-experiment requires a valid response!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-experiment requires a valid response!";
             }
 
             if (subParam == "yes")
@@ -435,7 +435,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-approx") {
             if (i + 1 > argc) {
-                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-approx requires a valid response!";
+                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-approx requires a valid response!";
             }
 
             if (subParam == "yes")
@@ -445,7 +445,7 @@ void Params::inputParams(int argc, char *argv[]) {
         }
 
         else {
-            fatalstream(EXIT_INVALID_PARAMETERS) << "Parameter '" << paramPrefix << "' is not recognised!";
+            FATAL(EXIT_INVALID_PARAMETERS) << "Parameter '" << paramPrefix << "' is not recognised!";
         }
 
     }
@@ -456,40 +456,40 @@ void Params::inputParams(int argc, char *argv[]) {
 
 void Params::validateParams() {
     if (audioFileName.empty() && !readStream)
-        fatalstream(EXIT_INVALID_PARAMETERS) << "Audio file name is empty!";
+        FATAL(EXIT_INVALID_PARAMETERS) << "Audio file name is empty!";
 
     if (subtitleFileName.empty() && !usingTranscript)
-        fatalstream(EXIT_INVALID_PARAMETERS) << "Subtitle file name is empty!";
+        FATAL(EXIT_INVALID_PARAMETERS) << "Subtitle file name is empty!";
 
     if (transcriptFileName.empty() && usingTranscript)
-        fatalstream(EXIT_INVALID_FILE) << "Transcript file name is empty!";
+        FATAL(EXIT_INVALID_FILE) << "Transcript file name is empty!";
 
     if (usingTranscript && chosenAlignerType == approxAligner)
-        fatalstream(EXIT_INVALID_PARAMETERS) << "Approx alligner doesn't work with text files";
+        FATAL(EXIT_INVALID_PARAMETERS) << "Approx alligner doesn't work with text files";
 
     if (modelPath.empty())
-        debugstream << "Using default Model Path.";
+        DEBUG << "Using default Model Path.";
 
     if (dictPath.empty())
-        debugstream << "Using default Dictionary Path.";
+        DEBUG << "Using default Dictionary Path.";
 
     if (lmPath.empty())
-        debugstream << "Using default LM Path.";
+        DEBUG << "Using default LM Path.";
 
     if (logPath.empty())
-        debugstream << "Using default Log Path.";
+        DEBUG << "Using default Log Path.";
 
     if (fsgPath.empty())
-        debugstream << "Using default FSG Path.";
+        DEBUG << "Using default FSG Path.";
 
     if (phoneticlmPath.empty())
-        debugstream << "Using default Phonetic LM Path.";
+        DEBUG << "Using default Phonetic LM Path.";
 
     if (phonemeLogPath.empty())
-        debugstream << "Using default Phoneme Log Path.";
+        DEBUG << "Using default Phoneme Log Path.";
 
     if (alignerLogPath.empty())
-        debugstream << "Using default Aligner Log Path.";
+        DEBUG << "Using default Aligner Log Path.";
 
     if (readStream) {
         audioFileName = "stdin";
@@ -512,7 +512,7 @@ void Params::validateParams() {
         case karaoke:   outputFileName += ".srt";
             break;
 
-        default:        fatalstream(EXIT_UNKNOWN) << "An error occurred while choosing output format!";
+        default:        FATAL(EXIT_UNKNOWN) << "An error occurred while choosing output format!";
             exit(2);
         }
     }
@@ -524,47 +524,47 @@ void Params::validateParams() {
         grammarType = quick_lm;
 
     if (useFSG && transcribe) {
-        fatalstream(EXIT_INCOMPATIBLE_PARAMETERS) << "FSG and Transcribing are not compatible!";
+        FATAL(EXIT_INCOMPATIBLE_PARAMETERS) << "FSG and Transcribing are not compatible!";
     }
 
     if (searchPhonemes && transcribe) {
-        fatalstream(EXIT_INCOMPATIBLE_PARAMETERS) << "Sorry, currently phoneme transcribing is not supported!";
+        FATAL(EXIT_INCOMPATIBLE_PARAMETERS) << "Sorry, currently phoneme transcribing is not supported!";
     }
 
     printParams();
 }
 
 void Params::printParams() const noexcept {
-    verbosestream << "audioFileName       : " << audioFileName;
+    VERBOSE << "audioFileName       : " << audioFileName;
     if (!usingTranscript)
-        verbosestream << "subtitleFileName    : " << subtitleFileName;
+        VERBOSE << "subtitleFileName    : " << subtitleFileName;
     else
-        verbosestream << "transcriptFileName	: " << transcriptFileName;
-    verbosestream << "outputFileName      : " << outputFileName;
-    verbosestream << "modelPath           : " << modelPath;
-    verbosestream << "lmPath              : " << lmPath;
-    verbosestream << "dictPath            : " << dictPath;
-    verbosestream << "fsgPath             : " << fsgPath;
-    verbosestream << "phoneticlmPath      : " << phoneticlmPath;
-    verbosestream << "logPath             : " << logPath;
-    verbosestream << "phonemeLogPath      : " << phonemeLogPath;
-    verbosestream << "alignerLogPath      : " << alignerLogPath;
-    verbosestream << "sampleWindow        : " << sampleWindow;
-    verbosestream << "audioWindow         : " << audioWindow;
-    verbosestream << "searchWindow        : " << searchWindow;
-    verbosestream << "chosenAlignerType   : " << chosenAlignerType;
-    verbosestream << "grammarType         : " << grammarType;
-    verbosestream << "outputFormat        : " << outputFormat;
-    verbosestream << "printOption         : " << printOption;
-    verbosestream << "verbosity           : " << verbosity;
-    verbosestream << "useFSG              : " << useFSG;
-    verbosestream << "transcribe          : " << transcribe;
-    verbosestream << "useBatchMode        : " << useBatchMode;
-    verbosestream << "ExperimentalParams  : " << useExperimentalParams;
-    verbosestream << "searchPhonemes      : " << searchPhonemes;
-    verbosestream << "displayRecognised   : " << displayRecognised;
-    verbosestream << "readStream          : " << readStream;
-    verbosestream << "quickDict           : " << quickDict;
-    verbosestream << "quickLM             : " << quickLM;
-    verbosestream << "\n\n=====================================================\n";
+        VERBOSE << "transcriptFileName	: " << transcriptFileName;
+    VERBOSE << "outputFileName      : " << outputFileName;
+    VERBOSE << "modelPath           : " << modelPath;
+    VERBOSE << "lmPath              : " << lmPath;
+    VERBOSE << "dictPath            : " << dictPath;
+    VERBOSE << "fsgPath             : " << fsgPath;
+    VERBOSE << "phoneticlmPath      : " << phoneticlmPath;
+    VERBOSE << "logPath             : " << logPath;
+    VERBOSE << "phonemeLogPath      : " << phonemeLogPath;
+    VERBOSE << "alignerLogPath      : " << alignerLogPath;
+    VERBOSE << "sampleWindow        : " << sampleWindow;
+    VERBOSE << "audioWindow         : " << audioWindow;
+    VERBOSE << "searchWindow        : " << searchWindow;
+    VERBOSE << "chosenAlignerType   : " << chosenAlignerType;
+    VERBOSE << "grammarType         : " << grammarType;
+    VERBOSE << "outputFormat        : " << outputFormat;
+    VERBOSE << "printOption         : " << printOption;
+    VERBOSE << "verbosity           : " << verbosity;
+    VERBOSE << "useFSG              : " << useFSG;
+    VERBOSE << "transcribe          : " << transcribe;
+    VERBOSE << "useBatchMode        : " << useBatchMode;
+    VERBOSE << "ExperimentalParams  : " << useExperimentalParams;
+    VERBOSE << "searchPhonemes      : " << searchPhonemes;
+    VERBOSE << "displayRecognised   : " << displayRecognised;
+    VERBOSE << "readStream          : " << readStream;
+    VERBOSE << "quickDict           : " << quickDict;
+    VERBOSE << "quickLM             : " << quickLM;
+    VERBOSE << "\n\n=====================================================\n";
 }

--- a/src/lib_ccaligner/params.cpp
+++ b/src/lib_ccaligner/params.cpp
@@ -465,7 +465,7 @@ void Params::validateParams() {
         fatalstream(EXIT_INVALID_FILE) << "Transcript file name is empty!";
 
     if (usingTranscript && chosenAlignerType == approxAligner)
-        fatalstream(EXIT_INVALID_PARAMETERS) << "Approx alligner doesn't work with text files");
+        fatalstream(EXIT_INVALID_PARAMETERS) << "Approx alligner doesn't work with text files";
 
     if (modelPath.empty())
         debugstream << "Using default Model Path.";

--- a/src/lib_ccaligner/params.cpp
+++ b/src/lib_ccaligner/params.cpp
@@ -64,7 +64,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         if (paramPrefix == "-wav") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-wav requires a path to valid wave!";
+                FATAL(IncompleteParameters) << "-wav requires a path to valid wave!";
             }
 
             audioFileName = subParam;
@@ -72,7 +72,7 @@ void Params::inputParams(int argc, char *argv[]) {
         }
         else if (paramPrefix == "-raw") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-raw requires a path to valid raw wave!";
+                FATAL(IncompleteParameters) << "-raw requires a path to valid raw wave!";
             }
 
             audioFileName = subParam;
@@ -85,7 +85,7 @@ void Params::inputParams(int argc, char *argv[]) {
         }
         else if (paramPrefix == "-srt") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-srt requires a path to valid SubRip subtitle file!";
+                FATAL(IncompleteParameters) << "-srt requires a path to valid SubRip subtitle file!";
             }
 
             usingTranscript = false;
@@ -94,7 +94,7 @@ void Params::inputParams(int argc, char *argv[]) {
         }
         else if (paramPrefix == "-txt") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-txt requires a path to valid transcript file!";
+                FATAL(IncompleteParameters) << "-txt requires a path to valid transcript file!";
             }
 
             usingTranscript = true;
@@ -107,7 +107,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-out") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-out requires a valid output filename!";
+                FATAL(IncompleteParameters) << "-out requires a valid output filename!";
             }
 
             outputFileName = subParam;
@@ -116,7 +116,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-oFormat") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-oFormat requires a valid output format";
+                FATAL(IncompleteParameters) << "-oFormat requires a valid output format";
             }
 
             if (subParam == "srt")
@@ -135,7 +135,7 @@ void Params::inputParams(int argc, char *argv[]) {
                 outputFormat = console;
 
             else {
-                FATAL(EXIT_INVALID_PARAMETERS) << "-oFormat requires a valid output format!";
+                FATAL(InvalidParameters) << "-oFormat requires a valid output format!";
             }
 
             i++;
@@ -143,7 +143,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-model") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-model requires a path to valid acoustic model!";
+                FATAL(IncompleteParameters) << "-model requires a path to valid acoustic model!";
             }
 
             modelPath = subParam;
@@ -152,7 +152,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-lm") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-lm requires a path to language model!";
+                FATAL(IncompleteParameters) << "-lm requires a path to language model!";
             }
 
             lmPath = subParam;
@@ -162,7 +162,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-dict") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-dict requires a path to a valid dictionary file!";
+                FATAL(IncompleteParameters) << "-dict requires a path to a valid dictionary file!";
             }
 
             dictPath = subParam;
@@ -172,7 +172,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-fsg") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-fsg requires a path to a valid directory containing FSG files!";
+                FATAL(IncompleteParameters) << "-fsg requires a path to a valid directory containing FSG files!";
             }
 
             fsgPath = subParam;
@@ -182,7 +182,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-log") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-log requires a path to a valid output log file!";
+                FATAL(IncompleteParameters) << "-log requires a path to a valid output log file!";
             }
 
             logPath = subParam;
@@ -191,7 +191,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-phoneLM") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-phoneLM requires a path to a valid phonetic language model!";
+                FATAL(IncompleteParameters) << "-phoneLM requires a path to a valid phonetic language model!";
 
             }
 
@@ -201,7 +201,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-alignerLog") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-alignerLog requires a path to a valid output log file!";
+                FATAL(IncompleteParameters) << "-alignerLog requires a path to a valid output log file!";
 
             }
 
@@ -211,7 +211,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-phoneLog") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-phoneLog requires a path to a valid output log file!";
+                FATAL(IncompleteParameters) << "-phoneLog requires a path to a valid output log file!";
 
             }
 
@@ -221,7 +221,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "--enable-phonemes") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "--enable-phonemes requires a valid response!";
+                FATAL(IncompleteParameters) << "--enable-phonemes requires a valid response!";
 
             }
 
@@ -233,7 +233,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "--generate-grammar") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "--generate-grammar requires a valid response!";
+                FATAL(IncompleteParameters) << "--generate-grammar requires a valid response!";
 
             }
 
@@ -259,7 +259,7 @@ void Params::inputParams(int argc, char *argv[]) {
                 grammarType = vocab;
 
             else {
-                FATAL(EXIT_INVALID_PARAMETERS) << "--generate-grammar requires a valid response!";
+                FATAL(InvalidParameters) << "--generate-grammar requires a valid response!";
             }
 
             i++;
@@ -267,7 +267,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "--quick-dict") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "--quick-dict requires a valid response!";
+                FATAL(IncompleteParameters) << "--quick-dict requires a valid response!";
             }
 
             if (subParam == "yes")
@@ -278,7 +278,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "--quick-lm") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "--quick-lm requires a valid response!";
+                FATAL(IncompleteParameters) << "--quick-lm requires a valid response!";
             }
 
             if (subParam == "yes")
@@ -289,7 +289,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "--print-aligned") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "--print-aligned requires a valid response!";
+                FATAL(IncompleteParameters) << "--print-aligned requires a valid response!";
             }
 
             if (subParam == "yes")
@@ -308,7 +308,7 @@ void Params::inputParams(int argc, char *argv[]) {
                 printOption = printAsKaraoke;
 
             else {
-                FATAL(EXIT_INVALID_PARAMETERS) << "--print-aligned requires a valid response!";
+                FATAL(InvalidParameters) << "--print-aligned requires a valid response!";
             }
 
             i++;
@@ -316,7 +316,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "--use-fsg") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "--use-fsg requires a valid response!";
+                FATAL(IncompleteParameters) << "--use-fsg requires a valid response!";
             }
 
             if (subParam == "yes")
@@ -327,7 +327,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-transcribe") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-transcribe requires a valid response!";
+                FATAL(IncompleteParameters) << "-transcribe requires a valid response!";
             }
 
             if (subParam == "yes")
@@ -339,7 +339,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-verbosity") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-verbose requires a valid response!";
+                FATAL(IncompleteParameters) << "-verbose requires a valid response!";
             }
 
             if (subParam == "verbose")
@@ -360,7 +360,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "--display-recognised") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "--display-recognised requires a valid response!";
+                FATAL(IncompleteParameters) << "--display-recognised requires a valid response!";
             }
 
             if (subParam == "no")
@@ -371,13 +371,13 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-searchWindow") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-searchWindow requires an integer value to determine the search scope!";
+                FATAL(IncompleteParameters) << "-searchWindow requires an integer value to determine the search scope!";
             }
 
             searchWindow = std::strtoul(subParam.c_str(), nullptr, 10);
 
             if (errno) {
-                FATAL(EXIT_FAILURE) << "Invalid value passed to -searchWindow : " << strerror(errno);
+                FATAL(UnknownError) << "Invalid value passed to -searchWindow : " << strerror(errno);
             }
 
             i++;
@@ -385,13 +385,13 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-sampleWindow") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-sampleWindow requires a valid integer value to determine the recognition scope!";
+                FATAL(IncompleteParameters) << "-sampleWindow requires a valid integer value to determine the recognition scope!";
             }
 
             sampleWindow = std::strtoul(subParam.c_str(), nullptr, 10);
 
             if (errno) {
-                FATAL(EXIT_FAILURE) << "Invalid value passed to -sampleWindow : " << strerror(errno);
+                FATAL(UnknownError) << "Invalid value passed to -sampleWindow : " << strerror(errno);
             }
 
             i++;
@@ -399,13 +399,13 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-audioWindow") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-audioWindow requires a valid integer value in milliseconds to determine the recognition scope!";
+                FATAL(IncompleteParameters) << "-audioWindow requires a valid integer value in milliseconds to determine the recognition scope!";
             }
 
             audioWindow = std::strtoul(subParam.c_str(), nullptr, 10);
 
             if (errno) {
-                FATAL(EXIT_FAILURE) << "Invalid value passed to -audioWindow : " << strerror(errno);
+                FATAL(UnknownError) << "Invalid value passed to -audioWindow : " << strerror(errno);
             }
 
             i++;
@@ -413,7 +413,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-useBatchMode") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-useBatchMode requires a valid response!";
+                FATAL(IncompleteParameters) << "-useBatchMode requires a valid response!";
             }
 
             if (subParam == "yes")
@@ -424,7 +424,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-experiment") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-experiment requires a valid response!";
+                FATAL(IncompleteParameters) << "-experiment requires a valid response!";
             }
 
             if (subParam == "yes")
@@ -435,7 +435,7 @@ void Params::inputParams(int argc, char *argv[]) {
 
         else if (paramPrefix == "-approx") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS) << "-approx requires a valid response!";
+                FATAL(IncompleteParameters) << "-approx requires a valid response!";
             }
 
             if (subParam == "yes")
@@ -445,7 +445,7 @@ void Params::inputParams(int argc, char *argv[]) {
         }
 
         else {
-            FATAL(EXIT_INVALID_PARAMETERS) << "Parameter '" << paramPrefix << "' is not recognised!";
+            FATAL(InvalidParameters) << "Parameter '" << paramPrefix << "' is not recognised!";
         }
 
     }
@@ -456,16 +456,16 @@ void Params::inputParams(int argc, char *argv[]) {
 
 void Params::validateParams() {
     if (audioFileName.empty() && !readStream)
-        FATAL(EXIT_INVALID_PARAMETERS) << "Audio file name is empty!";
+        FATAL(InvalidParameters) << "Audio file name is empty!";
 
     if (subtitleFileName.empty() && !usingTranscript)
-        FATAL(EXIT_INVALID_PARAMETERS) << "Subtitle file name is empty!";
+        FATAL(InvalidParameters) << "Subtitle file name is empty!";
 
     if (transcriptFileName.empty() && usingTranscript)
-        FATAL(EXIT_INVALID_FILE) << "Transcript file name is empty!";
+        FATAL(InvalidFile) << "Transcript file name is empty!";
 
     if (usingTranscript && chosenAlignerType == approxAligner)
-        FATAL(EXIT_INVALID_PARAMETERS) << "Approx alligner doesn't work with text files";
+        FATAL(InvalidParameters) << "Approx alligner doesn't work with text files";
 
     if (modelPath.empty())
         DEBUG << "Using default Model Path.";
@@ -512,7 +512,7 @@ void Params::validateParams() {
         case karaoke:   outputFileName += ".srt";
             break;
 
-        default:        FATAL(EXIT_UNKNOWN) << "An error occurred while choosing output format!";
+        default:        FATAL(UnknownError) << "An error occurred while choosing output format!";
             exit(2);
         }
     }
@@ -524,11 +524,11 @@ void Params::validateParams() {
         grammarType = quick_lm;
 
     if (useFSG && transcribe) {
-        FATAL(EXIT_INCOMPATIBLE_PARAMETERS) << "FSG and Transcribing are not compatible!";
+        FATAL(IncompatibleParameters) << "FSG and Transcribing are not compatible!";
     }
 
     if (searchPhonemes && transcribe) {
-        FATAL(EXIT_INCOMPATIBLE_PARAMETERS) << "Sorry, currently phoneme transcribing is not supported!";
+        FATAL(IncompatibleParameters) << "Sorry, currently phoneme transcribing is not supported!";
     }
 
     printParams();

--- a/src/lib_ccaligner/params.cpp
+++ b/src/lib_ccaligner/params.cpp
@@ -70,7 +70,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-wav requires a path to valid wave!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-wav requires a path to valid wave!";
             }
 
             audioFileName = subParam;
@@ -78,7 +78,7 @@ void Params::inputParams(int argc, char *argv[])
         }
         else if (paramPrefix == "-raw") {
             if (i + 1 > argc) {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-raw requires a path to valid raw wave!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-raw requires a path to valid raw wave!";
             }
 
             audioFileName = subParam;
@@ -93,7 +93,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-srt requires a path to valid SubRip subtitle file!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-srt requires a path to valid SubRip subtitle file!";
             }
 
             subtitleFileName = subParam;
@@ -109,7 +109,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-out requires a valid output filename!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-out requires a valid output filename!";
             }
 
             outputFileName = subParam;
@@ -120,7 +120,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-oFormat requires a valid output format");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-oFormat requires a valid output format";
             }
 
             if(subParam  == "srt")
@@ -140,7 +140,7 @@ void Params::inputParams(int argc, char *argv[])
 
             else
             {
-                FATAL(EXIT_INVALID_PARAMETERS, "-oFormat requires a valid output format!");
+                fatalstream(EXIT_INVALID_PARAMETERS) << "-oFormat requires a valid output format!";
             }
 
             i++;
@@ -150,7 +150,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-model requires a path to valid acoustic model!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-model requires a path to valid acoustic model!";
             }
 
             modelPath = subParam;
@@ -161,7 +161,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-lm requires a path to language model!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-lm requires a path to language model!";
             }
 
             lmPath = subParam;
@@ -173,7 +173,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-dict requires a path to a valid dictionary file!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-dict requires a path to a valid dictionary file!";
             }
 
             dictPath = subParam;
@@ -185,7 +185,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-fsg requires a path to a valid directory containing FSG files!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-fsg requires a path to a valid directory containing FSG files!";
             }
 
             fsgPath = subParam;
@@ -197,7 +197,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-log requires a path to a valid output log file!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-log requires a path to a valid output log file!";
             }
 
             logPath = subParam;
@@ -208,7 +208,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-phoneLM requires a path to a valid phonetic language model!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-phoneLM requires a path to a valid phonetic language model!";
 
             }
 
@@ -220,7 +220,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-phoneLog requires a path to a valid output log file!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-phoneLog requires a path to a valid output log file!";
 
             }
 
@@ -232,7 +232,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "--enable-phonemes requires a valid response!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "--enable-phonemes requires a valid response!";
 
             }
 
@@ -246,7 +246,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "--generate-grammar requires a valid response!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "--generate-grammar requires a valid response!";
 
             }
 
@@ -273,7 +273,7 @@ void Params::inputParams(int argc, char *argv[])
 
             else
             {
-                FATAL(EXIT_INVALID_PARAMETERS, "--generate-grammar requires a valid response!");
+                fatalstream(EXIT_INVALID_PARAMETERS) << "--generate-grammar requires a valid response!";
             }
 
             i++;
@@ -283,7 +283,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "--quick-dict requires a valid response!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "--quick-dict requires a valid response!";
             }
 
             if(subParam == "yes")
@@ -296,7 +296,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "--quick-lm requires a valid response!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "--quick-lm requires a valid response!";
             }
 
             if(subParam == "yes")
@@ -309,7 +309,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "--print-aligned requires a valid response!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "--print-aligned requires a valid response!";
             }
 
             if(subParam  == "yes")
@@ -329,7 +329,7 @@ void Params::inputParams(int argc, char *argv[])
 
             else
             {
-                FATAL(EXIT_INVALID_PARAMETERS, "--print-aligned requires a valid response!");
+                fatalstream(EXIT_INVALID_PARAMETERS) << "--print-aligned requires a valid response!";
             }
 
             i++;
@@ -339,7 +339,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "--use-fsg requires a valid response!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "--use-fsg requires a valid response!";
             }
 
             if(subParam  == "yes")
@@ -352,7 +352,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-transcribe requires a valid response!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-transcribe requires a valid response!";
             }
 
             if(subParam  == "yes")
@@ -366,7 +366,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-verbose requires a valid response!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-verbose requires a valid response!";
             }
 
             if(subParam  == "no")
@@ -379,7 +379,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "--display-recognised requires a valid response!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "--display-recognised requires a valid response!";
             }
 
             if(subParam  == "no")
@@ -392,14 +392,14 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-searchWindow requires an integer value to determine the search scope!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-searchWindow requires an integer value to determine the search scope!";
             }
 
             searchWindow = std::strtoul( subParam.c_str(), nullptr, 10 );
 
             if ( errno )
             {
-                FATAL(EXIT_FAILURE, "Invalid value passed to -searchWindow : %s", strerror(errno));
+                fatalstream(EXIT_FAILURE) << "Invalid value passed to -searchWindow : " << strerror(errno);
             }
 
             i++;
@@ -409,14 +409,14 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-sampleWindow requires a valid integer value to determine the recognition scope!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-sampleWindow requires a valid integer value to determine the recognition scope!";
             }
 
             sampleWindow = std::strtoul( subParam.c_str(), nullptr, 10 );
 
             if ( errno )
             {
-                FATAL(EXIT_FAILURE, "Invalid value passed to -sampleWindow : %s", strerror(errno));
+                fatalstream(EXIT_FAILURE) << "Invalid value passed to -sampleWindow : " << strerror(errno);
             }
 
             i++;
@@ -426,14 +426,14 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-audioWindow requires a valid integer value in milliseconds to determine the recognition scope!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-audioWindow requires a valid integer value in milliseconds to determine the recognition scope!";
             }
 
             audioWindow = std::strtoul( subParam.c_str(), nullptr, 10 );
 
             if ( errno )
             {
-                FATAL(EXIT_FAILURE, "Invalid value passed to -audioWindow : %s", strerror(errno));
+                fatalstream(EXIT_FAILURE) << "Invalid value passed to -audioWindow : " << strerror(errno);
             }
 
             i++;
@@ -443,7 +443,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-useBatchMode requires a valid response!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-useBatchMode requires a valid response!";
             }
 
             if(subParam  == "yes")
@@ -456,7 +456,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-experiment requires a valid response!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-experiment requires a valid response!";
             }
 
             if(subParam  == "yes")
@@ -469,7 +469,7 @@ void Params::inputParams(int argc, char *argv[])
         {
             if(i+1 > argc)
             {
-                FATAL(EXIT_INCOMPLETE_PARAMETERS, "-approx requires a valid response!");
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-approx requires a valid response!";
             }
 
             if(subParam  == "yes")
@@ -480,7 +480,7 @@ void Params::inputParams(int argc, char *argv[])
 
         else
         {
-            FATAL(EXIT_INVALID_PARAMETERS, "Parameter '%s' is not recognised!", paramPrefix.c_str());
+            fatalstream(EXIT_INVALID_PARAMETERS) << "Parameter '"<< paramPrefix <<"' is not recognised!";
         }
 
     }
@@ -492,31 +492,31 @@ void Params::inputParams(int argc, char *argv[])
 void Params::validateParams()
 {
     if(audioFileName.empty() && !readStream)
-        FATAL(EXIT_INVALID_PARAMETERS, "Audio file name is empty!");
+        fatalstream(EXIT_INVALID_PARAMETERS) << "Audio file name is empty!";
 
     if(subtitleFileName.empty())
-        FATAL(EXIT_INVALID_PARAMETERS, "Subtitle file name is empty!");
+        fatalstream(EXIT_INVALID_PARAMETERS) << "Subtitle file name is empty!";
 
     if(modelPath.empty())
-        LOG("Using default Model Path.");
+        debugstream << "Using default Model Path.";
 
     if(dictPath.empty())
-        LOG("Using default Dictionary Path.");
+        debugstream << "Using default Dictionary Path.";
 
     if(lmPath.empty())
-        LOG("Using default LM Path.");
+        debugstream << "Using default LM Path.";
 
     if(logPath.empty())
-        LOG("Using default Log Path.");
+        debugstream << "Using default Log Path.";
 
     if(fsgPath.empty())
-        LOG("Using default FSG Path.");
+        debugstream << "Using default FSG Path.";
 
     if(phoneticlmPath.empty())
-        LOG("Using default Phonetic LM Path.");
+        debugstream << "Using default Phonetic LM Path.";
 
     if(phonemeLogPath.empty())
-        LOG("Using default Phoneme Log Path.");
+        debugstream << "Using default Phoneme Log Path.";
 
     if(readStream)
     {
@@ -541,7 +541,7 @@ void Params::validateParams()
             case karaoke:   outputFileName += ".srt";
                 break;
 
-            default:        FATAL(EXIT_UNKNOWN, "An error occurred while choosing output format!");
+            default:        fatalstream(EXIT_UNKNOWN) << "An error occurred while choosing output format!";
                 exit(2);
         }
     }
@@ -554,12 +554,12 @@ void Params::validateParams()
 
     if(useFSG && transcribe)
     {
-        FATAL(EXIT_INCOMPATIBLE_PARAMETERS , "FSG and Transcribing are not compatible!");
+        fatalstream(EXIT_INCOMPATIBLE_PARAMETERS ) << "FSG and Transcribing are not compatible!";
     }
 
     if(searchPhonemes && transcribe)
     {
-        FATAL(EXIT_INCOMPATIBLE_PARAMETERS , "Sorry, currently phoneme transcribing is not supported!");
+        fatalstream(EXIT_INCOMPATIBLE_PARAMETERS ) << "Sorry, currently phoneme transcribing is not supported!";
     }
 
     if(verbosity)

--- a/src/lib_ccaligner/params.cpp
+++ b/src/lib_ccaligner/params.cpp
@@ -33,8 +33,6 @@ Params::Params() noexcept
       grammarType(complete_grammar),
       outputFormat(xml),
       printOption(printBothWithDistinctColors),
-
-      verbosity(true),
       useFSG(),
       transcribe(),
       useBatchMode(),
@@ -51,6 +49,7 @@ Params::Params() noexcept
     localTime.erase(std::strftime(&localTime.front(), localTime.size(), "%d-%m-%Y-%H-%M-%S", std::localtime(&now)));
 
     logPath = "tempFiles/" + localTime + ".log";
+    alignerLogPath = "tempFiles/aligner-" + localTime + ".log";
     phonemeLogPath = "tempFiles/phoneme-" + localTime + ".log";
 }
 
@@ -216,6 +215,16 @@ void Params::inputParams(int argc, char *argv[])
             i++;
         }
 
+        else if (paramPrefix == "-alignerLog") {
+            if (i + 1 > argc) {
+                fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-alignerLog requires a path to a valid output log file!";
+
+            }
+
+            alignerLogPath = subParam;
+            i++;
+        }
+
         else if(paramPrefix == "-phoneLog")
         {
             if(i+1 > argc)
@@ -362,15 +371,23 @@ void Params::inputParams(int argc, char *argv[])
         }
 
 
-        else if(paramPrefix== "-verbose")
-        {
-            if(i+1 > argc)
-            {
+        else if (paramPrefix == "-verbosity") {
+            if (i + 1 > argc) {
                 fatalstream(EXIT_INCOMPLETE_PARAMETERS) << "-verbose requires a valid response!";
             }
 
-            if(subParam  == "no")
-                verbosity = false;
+            if (subParam == "verbose")
+                getLogger().setMinimumOutputLevel(Logger::Level::verbose);
+            else if (subParam == "debug")
+                getLogger().setMinimumOutputLevel(Logger::Level::debug);
+            else if (subParam == "info")
+                getLogger().setMinimumOutputLevel(Logger::Level::info);
+            else if (subParam == "warning")
+                getLogger().setMinimumOutputLevel(Logger::Level::warning);
+            else if (subParam == "error")
+                getLogger().setMinimumOutputLevel(Logger::Level::error);
+            else if (subParam == "nolog")
+                getLogger().setMinimumOutputLevel(Logger::Level::nolog);
 
             i++;
         }
@@ -518,6 +535,9 @@ void Params::validateParams()
     if(phonemeLogPath.empty())
         debugstream << "Using default Phoneme Log Path.";
 
+    if (alignerLogPath.empty())
+        debugstream << "Using default Phoneme Log Path.";
+
     if(readStream)
     {
         audioFileName = "stdin";
@@ -562,49 +582,45 @@ void Params::validateParams()
         fatalstream(EXIT_INCOMPATIBLE_PARAMETERS ) << "Sorry, currently phoneme transcribing is not supported!";
     }
 
-    if(verbosity)
-    {
-        //should_log = true;
-        printParams();
-    }
+    printParams();
 }
 
 void Params::printParams() const noexcept
 {
-    std::cout<<"audioFileName       : "<<audioFileName<<"\n";
-    std::cout<<"subtitleFileName    : "<<subtitleFileName<<"\n";
-    std::cout<<"outputFileName      : "<<outputFileName<<"\n";
-    std::cout<<"modelPath           : "<<modelPath<<"\n";
-    std::cout<<"lmPath              : "<<lmPath<<"\n";
-    std::cout<<"dictPath            : "<<dictPath<<"\n";
-    std::cout<<"fsgPath             : "<<fsgPath<<"\n";
+    verbosestream << "audioFileName       : " << audioFileName;
+    verbosestream << "subtitleFileName    : " << subtitleFileName;
+    verbosestream << "outputFileName      : " << outputFileName;
+    verbosestream << "modelPath           : " << modelPath;
+    verbosestream << "lmPath              : " << lmPath;
+    verbosestream << "dictPath            : " << dictPath;
+    verbosestream << "fsgPath             : " << fsgPath;
 
-    std::cout<<"phoneticlmPath      : "<<phoneticlmPath<<"\n";
+    verbosestream << "phoneticlmPath      : " << phoneticlmPath;
 
-    std::cout<<"logPath             : "<<logPath<<"\n";
-    std::cout<<"phonemeLogPath      : "<<phonemeLogPath<<"\n";
+    verbosestream << "logPath             : " << logPath;
+    verbosestream << "alignerLogPath      : " << alignerLogPath;
+    verbosestream << "phonemeLogPath      : " << phonemeLogPath;
 
-    std::cout<<"sampleWindow        : "<<sampleWindow<<"\n";
-    std::cout<<"audioWindow         : "<<audioWindow<<"\n";
-    std::cout<<"searchWindow        : "<<searchWindow<<"\n";
+    verbosestream << "sampleWindow        : " << sampleWindow;
+    verbosestream << "audioWindow         : " << audioWindow;
+    verbosestream << "searchWindow        : " << searchWindow;
 
 
-    std::cout<<"chosenAlignerType   : "<<chosenAlignerType<<"\n";
-    std::cout<<"grammarType         : "<<grammarType<<"\n";
-    std::cout<<"outputFormat        : "<<outputFormat<<"\n";
-    std::cout<<"printOption         : "<<printOption<<"\n";
+    verbosestream << "chosenAlignerType   : " << chosenAlignerType;
+    verbosestream << "grammarType         : " << grammarType;
+    verbosestream << "outputFormat        : " << outputFormat;
+    verbosestream << "printOption         : " << printOption;
 
-    std::cout<<"verbosity           : "<<verbosity<<"\n";
-    std::cout<<"useFSG              : "<<useFSG<<"\n";
-    std::cout<<"transcribe          : "<<transcribe<<"\n";
-    std::cout<<"useBatchMode        : "<<useBatchMode<<"\n";
-    std::cout<<"ExperimentalParams  : "<< useExperimentalParams<<"\n";
-    std::cout<<"searchPhonemes      : "<<searchPhonemes<<"\n";
-    std::cout<<"displayRecognised   : "<<displayRecognised<<"\n";
-    std::cout<<"readStream          : "<<readStream<<"\n";
-    std::cout<<"quickDict           : " <<quickDict<<"\n";
-    std::cout<<"quickLM             : " <<quickLM<<"\n";
+    verbosestream << "useFSG              : " << useFSG;
+    verbosestream << "transcribe          : " << transcribe;
+    verbosestream << "useBatchMode        : " << useBatchMode;
+    verbosestream << "ExperimentalParams  : " << useExperimentalParams;
+    verbosestream << "searchPhonemes      : " << searchPhonemes;
+    verbosestream << "displayRecognised   : " << displayRecognised;
+    verbosestream << "readStream          : " << readStream;
+    verbosestream << "quickDict           : " << quickDict;
+    verbosestream << "quickLM             : " << quickLM;
 
-    std::cout<<"\n\n=====================================================\n\n";
+    verbosestream << "\n\n=====================================================\n\n";
 
 }

--- a/src/lib_ccaligner/params.h
+++ b/src/lib_ccaligner/params.h
@@ -17,7 +17,7 @@ class Params
 
     void validateParams();
 public:
-    std::string audioFileName, subtitleFileName, outputFileName, modelPath, lmPath, dictPath, fsgPath, logPath, phoneticlmPath, phonemeLogPath;
+    std::string audioFileName, subtitleFileName, outputFileName, modelPath, lmPath, dictPath, fsgPath, logPath, phoneticlmPath, phonemeLogPath, alignerLogPath;
     bool audioIsRaw;
     unsigned long searchWindow, sampleWindow, audioWindow;
     alignerType chosenAlignerType;

--- a/src/lib_ccaligner/phoneme_utils.cpp
+++ b/src/lib_ccaligner/phoneme_utils.cpp
@@ -120,7 +120,7 @@ std::vector<Phoneme> stringToPhoneme(const std::string &word)
         Phoneme phone = charToPhone(c);
         if (phone == "Noise")
         {
-            std::cout<<"Error converting "<<phone<<"\n";
+            LOG("Error converting %s", phone.c_str());
         }
 
         if (phone != lastPhoneme)

--- a/src/lib_ccaligner/phoneme_utils.cpp
+++ b/src/lib_ccaligner/phoneme_utils.cpp
@@ -120,7 +120,7 @@ std::vector<Phoneme> stringToPhoneme(const std::string &word)
         Phoneme phone = charToPhone(c);
         if (phone == "Noise")
         {
-            debugstream << "Error converting " << phone;
+            DEBUG << "Error converting " << phone;
         }
 
         if (phone != lastPhoneme)

--- a/src/lib_ccaligner/phoneme_utils.cpp
+++ b/src/lib_ccaligner/phoneme_utils.cpp
@@ -120,7 +120,7 @@ std::vector<Phoneme> stringToPhoneme(const std::string &word)
         Phoneme phone = charToPhone(c);
         if (phone == "Noise")
         {
-            LOG("Error converting %s", phone.c_str());
+            debugstream << "Error converting " << phone;
         }
 
         if (phone != lastPhoneme)

--- a/src/lib_ccaligner/phoneme_utils.h
+++ b/src/lib_ccaligner/phoneme_utils.h
@@ -16,7 +16,7 @@
 #define CCALIGNER_PHONEME_UTILS_H
 
 #include "commons.h"
-typedef std::string Phoneme;
+using Phoneme = std::string;
 
 std::wstring latin1ToWide(const std::string& s);
 const std::vector<std::pair<std::wregex, std::wstring>>& getReplacementRules();

--- a/src/lib_ccaligner/read_wav_file.cpp
+++ b/src/lib_ccaligner/read_wav_file.cpp
@@ -105,7 +105,7 @@ bool WaveFileData::decode()     //decodes the wave file
     if(format != "WAVE")
     {
         DEBUG << "Invalid WAV file format";
-        FATAL(EXIT_INVALID_FILE) << "Invalid WAV file format : " << format;
+        FATAL(InvalidFile) << "Invalid WAV file format : " << format;
     }
 
     DEBUG << "File format is identified as WAV";
@@ -123,13 +123,13 @@ bool WaveFileData::decode()     //decodes the wave file
     if(fmtIndex < 0)
     {
         DEBUG << "FMT subchunk not found!";
-        FATAL(EXIT_INVALID_FILE) << "FMT subchunk not found!";
+        FATAL(InvalidFile) << "FMT subchunk not found!";
     }
 
     if(dataIndex < 0)
     {
         DEBUG << "Data subchunk not found!";
-        FATAL(EXIT_INVALID_FILE) << "Data subchunk not found!";
+        FATAL(InvalidFile) << "Data subchunk not found!";
     }
 
     DEBUG << "FMT index : "<< fmtIndex <<" , DATA index : " << dataIndex;
@@ -138,21 +138,21 @@ bool WaveFileData::decode()     //decodes the wave file
 
     if(subChunk1ID != "fmt ")
     {
-        FATAL(EXIT_INVALID_FILE) << "Invalid SubChunk1ID : " << subChunk1ID;
+        FATAL(InvalidFile) << "Invalid SubChunk1ID : " << subChunk1ID;
     }
 
     unsigned long subChunk1Size = fourBytesToInt(_fileData, fmtIndex + 4);
 
     if(subChunk1Size != 16)
     {
-        FATAL(EXIT_INVALID_FILE) << "Not PCM, SubChunk1Size : " << subChunk1Size;
+        FATAL(InvalidFile) << "Not PCM, SubChunk1Size : " << subChunk1Size;
     }
 
     int audioFormat = twoBytesToInt(_fileData, fmtIndex + 8);
 
     if(audioFormat != 1)
     {
-        FATAL(EXIT_INVALID_FILE) << "Not PCM, AudioFormat : " << audioFormat;
+        FATAL(InvalidFile) << "Not PCM, AudioFormat : " << audioFormat;
     }
 
     DEBUG << "PCM : True";
@@ -161,7 +161,7 @@ bool WaveFileData::decode()     //decodes the wave file
 
     if(numChannels != 1)
     {
-        FATAL(EXIT_INVALID_FILE) << "Not Mono, NumChannels : " << numChannels;
+        FATAL(InvalidFile) << "Not Mono, NumChannels : " << numChannels;
     }
 
     DEBUG << "MONO : True";
@@ -170,7 +170,7 @@ bool WaveFileData::decode()     //decodes the wave file
 
     if(sampleRate != 16000)
     {
-        FATAL(EXIT_INVALID_FILE) << "Not 16000Hz SampleRate, SampleRate : " << sampleRate;
+        FATAL(InvalidFile) << "Not 16000Hz SampleRate, SampleRate : " << sampleRate;
     }
 
     DEBUG << "Sample Rate 16KHz : True";
@@ -183,21 +183,21 @@ bool WaveFileData::decode()     //decodes the wave file
 
     if(bitRate != 16)
     {
-        FATAL(EXIT_INVALID_FILE) << "Not 16 bits/sec, BitRate : " << bitRate;
+        FATAL(InvalidFile) << "Not 16 bits/sec, BitRate : " << bitRate;
     }
 
     DEBUG << "BitRate 16 bits/sec : True";
 
     if((byteRate != sampleRate * numChannels * bitRate/8) || (blockAlign != numChannels * bitRate/8))
     {
-        FATAL(EXIT_INVALID_FILE) << "Incorrect header, ByteRate and/or BlockAlign values do not match!";
+        FATAL(InvalidFile) << "Incorrect header, ByteRate and/or BlockAlign values do not match!";
     }
 
     std::string subChunk2ID (_fileData.begin() + dataIndex, _fileData.begin() + dataIndex + 4);
 
     if(subChunk2ID != "data")
     {
-        FATAL(EXIT_INVALID_FILE) << "Invalid SubChunk2ID : " << subChunk2ID;
+        FATAL(InvalidFile) << "Invalid SubChunk2ID : " << subChunk2ID;
     }
 
     unsigned long subChunk2Size = fourBytesToInt(_fileData, dataIndex + 4);
@@ -228,7 +228,7 @@ bool WaveFileData::openFile ()
 
     if (!infile)
     {
-        FATAL(EXIT_FILE_NOT_FOUND) << "Unable to open file : " << _fileName;
+        FATAL(FileNotFound) << "Unable to open file : " << _fileName;
     }
 
     DEBUG << "Reading file data";
@@ -245,7 +245,7 @@ bool WaveFileData::openFile ()
             return true;
         }
         else {
-            FATAL(EXIT_INVALID_FILE) << "Unable to read from file : " << _fileName;
+            FATAL(InvalidFile) << "Unable to read from file : " << _fileName;
             return false;
         }
     }
@@ -283,7 +283,7 @@ bool WaveFileData::openFile ()
     else
     {
         DEBUG << "Invalid WAV file";
-        FATAL(EXIT_INVALID_FILE) << "Invalid WAV file!";
+        FATAL(InvalidFile) << "Invalid WAV file!";
     }
 
     return true;
@@ -307,7 +307,7 @@ int WaveFileData::processStreamHeader()
         {
             if (riff[currentByteCount] != byteData)     //checking RIFF header
             {
-                FATAL(EXIT_INVALID_FILE) << "Invalid WAV file : Incorrect subChunk1ID!";
+                FATAL(InvalidFile) << "Invalid WAV file : Incorrect subChunk1ID!";
             }
 
             if (currentByteCount == 3)
@@ -326,7 +326,7 @@ int WaveFileData::processStreamHeader()
                 if (wave[currentByteCount - 8] != byteData) //checking WAVE format
                 {
                     DEBUG << "Error: Incorrect header";
-                    FATAL(EXIT_INVALID_FILE) << "Invalid WAV file : Incorrect Header!";
+                    FATAL(InvalidFile) << "Invalid WAV file : Incorrect Header!";
                 }
 
                 if (currentByteCount == 11)
@@ -342,7 +342,7 @@ int WaveFileData::processStreamHeader()
             }
         }
     }
-    FATAL(EXIT_UNKNOWN) << "Error occurred while processing stream header!";
+    FATAL(UnknownError) << "Error occurred while processing stream header!";
 }
 
 int WaveFileData::seekToEndOfSubChunk1ID(int remainingBytes)
@@ -382,10 +382,10 @@ int WaveFileData::seekToEndOfSubChunk1ID(int remainingBytes)
         if(readBytes > remainingBytes)
         {
             DEBUG << "SubChunk1 ('fmt') not found";
-            FATAL(EXIT_INVALID_FILE) << "Invalid WAV file: SubChunk1 ('fmt') not found!";
+            FATAL(InvalidFile) << "Invalid WAV file: SubChunk1 ('fmt') not found!";
         }
     }
-    FATAL(EXIT_UNKNOWN) << "Error occurred while checking SubChunk1ID";
+    FATAL(UnknownError) << "Error occurred while checking SubChunk1ID";
     return -1;
 }
 
@@ -416,28 +416,28 @@ int WaveFileData::validateSubChunk1(int remainingBytes)
 
     if(subChunk1Size != 16)
     {
-        FATAL(EXIT_INVALID_FILE) << "Invalid WAV file: Not PCM, SubChunk1Size: " << subChunk1Size;
+        FATAL(InvalidFile) << "Invalid WAV file: Not PCM, SubChunk1Size: " << subChunk1Size;
     }
 
     int audioFormat = twoBytesToInt(fmtBlock, 4);
 
     if(audioFormat != 1)
     {
-        FATAL(EXIT_INVALID_FILE) << "Invalid WAV file: Not PCM, AudioFormat: " << audioFormat;
+        FATAL(InvalidFile) << "Invalid WAV file: Not PCM, AudioFormat: " << audioFormat;
     }
 
     int numChannels = twoBytesToInt(fmtBlock, 6);
 
     if(numChannels != 1)
     {
-        FATAL(EXIT_INVALID_FILE) << "Invalid WAV file: Not Mono, NumChannels: " << numChannels;
+        FATAL(InvalidFile) << "Invalid WAV file: Not Mono, NumChannels: " << numChannels;
     }
 
     unsigned long sampleRate = fourBytesToInt(fmtBlock, 8);
 
     if(sampleRate != 16000)
     {
-        FATAL(EXIT_INVALID_FILE) << "Invalid WAV file: Not 16000Hz SampleRate, SampleRate: " << sampleRate;
+        FATAL(InvalidFile) << "Invalid WAV file: Not 16000Hz SampleRate, SampleRate: " << sampleRate;
     }
 
     unsigned long byteRate = fourBytesToInt(fmtBlock, 12);
@@ -448,12 +448,12 @@ int WaveFileData::validateSubChunk1(int remainingBytes)
 
     if(bitRate != 16)
     {
-        FATAL(EXIT_INVALID_FILE) << "Invalid WAV file: Not 16 bits/sec, BitRate: " << bitRate;
+        FATAL(InvalidFile) << "Invalid WAV file: Not 16 bits/sec, BitRate: " << bitRate;
     }
 
     if((byteRate != sampleRate * numChannels * bitRate/8) || (blockAlign != numChannels * bitRate/8))
     {
-        FATAL(EXIT_INVALID_FILE) << "Incorrect header, ByteRate and/or BlockAlign values do not match!";
+        FATAL(InvalidFile) << "Incorrect header, ByteRate and/or BlockAlign values do not match!";
     }
 
     return currentByteCount + 1;
@@ -491,10 +491,10 @@ int WaveFileData::seekToEndOfSubChunk2ID(int remainingBytes)
         if(readBytes > remainingBytes)
         {
             DEBUG << "SubChunk2 ('data') not found";
-            FATAL(EXIT_INVALID_FILE) << "SubChunk2 ('data') not found!";
+            FATAL(InvalidFile) << "SubChunk2 ('data') not found!";
         }
     }
-    FATAL(EXIT_UNKNOWN) << "Error occurred while reading SubChunk2!";
+    FATAL(UnknownError) << "Error occurred while reading SubChunk2!";
 }
 
 int WaveFileData::getNumberOfSamples()
@@ -605,7 +605,7 @@ bool WaveFileData::readStreamUsingBuffer()
 
     else
     {
-        FATAL(EXIT_INVALID_FILE) << "Invalid WAV file: SubChunk2 ('data') not found!";
+        FATAL(InvalidFile) << "Invalid WAV file: SubChunk2 ('data') not found!";
     }
 
     return true;
@@ -627,7 +627,7 @@ bool WaveFileData::read()   //decided the function based on set mode
         case readStreamIntoBuffer : DEBUG << "Opening mode chosen: readStreamIntoBuffer, proceeding";
                                     readStreamUsingBuffer();//from stream/pipe into buffer and then processing
                                     break;
-        default                   : FATAL(EXIT_INVALID_FILE)<<"Error choosing opening mode, please report!";
+        default                   : FATAL(InvalidFile)<<"Error choosing opening mode, please report!";
 
     }
     return true;

--- a/src/lib_ccaligner/read_wav_file.cpp
+++ b/src/lib_ccaligner/read_wav_file.cpp
@@ -33,7 +33,7 @@ bool WaveFileData::checkValidWave (const std::vector<unsigned char>& fileData)
      * 0         4   ChunkID          Contains the letters "RIFF" in ASCII form
      */
 
-    LOG("Checking chunkID, should be RIFF");
+    debugstream << "Checking chunkID, should be RIFF";
     std::string chunkID (fileData.begin(), fileData.begin() + 4);
     return chunkID == "RIFF";
 
@@ -104,76 +104,76 @@ bool WaveFileData::decode()     //decodes the wave file
 
     if(format != "WAVE")
     {
-        LOG("Invalid WAV file format");
-        FATAL(EXIT_INVALID_FILE, "Invalid WAV file format : %s ", format.c_str());
+        debugstream << "Invalid WAV file format";
+        fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file format : " << format;
     }
 
-    LOG("File format is identified as WAV");
+    debugstream << "File format is identified as WAV";
 
     /*
      * Apparently, this is just not it. The `fmt ` and `data`  chunk may not necessarily be in continuation.
      * There may occur inclusion of metadata. So, we'll need to find the location of these chunks.
      */
 
-    LOG("Finding FMT and DATA subchunks");
+    debugstream << "Finding FMT and DATA subchunks";
 
     int fmtIndex = findIndex(_fileData, "fmt ");
     int dataIndex = findIndex(_fileData, "data");
 
     if(fmtIndex < 0)
     {
-        LOG("FMT subchunk not found!");
-        FATAL(EXIT_INVALID_FILE, "FMT subchunk not found!");
+        debugstream << "FMT subchunk not found!";
+        fatalstream(EXIT_INVALID_FILE) << "FMT subchunk not found!";
     }
 
     if(dataIndex < 0)
     {
-        LOG("Data subchunk not found!");
-        FATAL(EXIT_INVALID_FILE, "Data subchunk not found!");
+        debugstream << "Data subchunk not found!";
+        fatalstream(EXIT_INVALID_FILE) << "Data subchunk not found!";
     }
 
-    LOG("FMT index : %d , DATA index :%d", fmtIndex, dataIndex);
+    debugstream << "FMT index : "<< fmtIndex <<" , DATA index : " << dataIndex;
 
     std::string subChunk1ID(_fileData.begin() + fmtIndex, _fileData.begin() + fmtIndex + 4);
 
     if(subChunk1ID != "fmt ")
     {
-        FATAL(EXIT_INVALID_FILE, "Invalid SubChunk1ID : %s", subChunk1ID.c_str());
+        fatalstream(EXIT_INVALID_FILE) << "Invalid SubChunk1ID : " << subChunk1ID;
     }
 
     unsigned long subChunk1Size = fourBytesToInt(_fileData, fmtIndex + 4);
 
     if(subChunk1Size != 16)
     {
-        FATAL(EXIT_INVALID_FILE, "Not PCM, SubChunk1Size : %lu", subChunk1Size);
+        fatalstream(EXIT_INVALID_FILE) << "Not PCM, SubChunk1Size : " << subChunk1Size;
     }
 
     int audioFormat = twoBytesToInt(_fileData, fmtIndex + 8);
 
     if(audioFormat != 1)
     {
-        FATAL(EXIT_INVALID_FILE, "Not PCM, AudioFormat : %d", audioFormat);
+        fatalstream(EXIT_INVALID_FILE) << "Not PCM, AudioFormat : " << audioFormat;
     }
 
-    LOG("PCM : True");
+    debugstream << "PCM : True";
 
     int numChannels = twoBytesToInt(_fileData, fmtIndex + 10);
 
     if(numChannels != 1)
     {
-        FATAL(EXIT_INVALID_FILE, "Not Mono, NumChannels : %d", numChannels);
+        fatalstream(EXIT_INVALID_FILE) << "Not Mono, NumChannels : " << numChannels;
     }
 
-    LOG("MONO : True");
+    debugstream << "MONO : True";
 
     unsigned long sampleRate = fourBytesToInt(_fileData, fmtIndex + 12);
 
     if(sampleRate != 16000)
     {
-        FATAL(EXIT_INVALID_FILE, "Not 16000Hz SampleRate, SampleRate : %lu", sampleRate);
+        fatalstream(EXIT_INVALID_FILE) << "Not 16000Hz SampleRate, SampleRate : " << sampleRate;
     }
 
-    LOG("Sample Rate 16KHz : True");
+    debugstream << "Sample Rate 16KHz : True";
 
     unsigned long byteRate = fourBytesToInt(_fileData, fmtIndex + 16);
 
@@ -183,29 +183,29 @@ bool WaveFileData::decode()     //decodes the wave file
 
     if(bitRate != 16)
     {
-        FATAL(EXIT_INVALID_FILE, "Not 16 bits/sec, BitRate : %d", bitRate);
+        fatalstream(EXIT_INVALID_FILE) << "Not 16 bits/sec, BitRate : " << bitRate;
     }
 
-    LOG("BitRate 16 bits/sec : True");
+    debugstream << "BitRate 16 bits/sec : True";
 
     if((byteRate != sampleRate * numChannels * bitRate/8) || (blockAlign != numChannels * bitRate/8))
     {
-        FATAL(EXIT_INVALID_FILE, "Incorrect header, ByteRate and/or BlockAlign values do not match!");
+        fatalstream(EXIT_INVALID_FILE) << "Incorrect header, ByteRate and/or BlockAlign values do not match!";
     }
 
     std::string subChunk2ID (_fileData.begin() + dataIndex, _fileData.begin() + dataIndex + 4);
 
     if(subChunk2ID != "data")
     {
-        FATAL(EXIT_INVALID_FILE, "Invalid SubChunk2ID : %s", subChunk2ID.c_str());
+        fatalstream(EXIT_INVALID_FILE) << "Invalid SubChunk2ID : " << subChunk2ID;
     }
 
     unsigned long subChunk2Size = fourBytesToInt(_fileData, dataIndex + 4);
 
     unsigned long int numSamples = subChunk2Size * 8 / ( numChannels * bitRate);
 
-    LOG("Number of samples : %lu", numSamples);
-    LOG("Reading samples");
+    debugstream << "Number of samples : " << numSamples;
+    debugstream << "Reading samples";
 
     for (unsigned long int i = 0; i < numSamples; i++)
     {
@@ -216,7 +216,7 @@ bool WaveFileData::decode()     //decodes the wave file
             int16_t sample = twoBytesToInt(_fileData, sampleIndex);
             _samples.push_back(sample);
     }
-    LOG("Successfully decoded");
+    debugstream << "Successfully decoded";
     return true;    //successfully decoded
 }
 
@@ -224,15 +224,15 @@ bool WaveFileData::openFile ()
 {
     std::ifstream infile (_fileName, std::ios::binary);
 
-    LOG("Trying to read from file : %s", _fileName.c_str());
+    debugstream << "Trying to read from file : " << _fileName;
 
     if (!infile)
     {
-        LOG("Error occured while opening file");
-        FATAL(EXIT_FILE_NOT_FOUND, "Unable to open file : %s", _fileName.c_str());
+        debugstream << "Error occured while opening file";
+        fatalstream(EXIT_FILE_NOT_FOUND, "Unable to open file : " << _fileName);
     }
 
-    LOG("Reading file data");
+    debugstream << "Reading file data";
 
     if (_isRawFile) { // handle raw audio files
         infile.seekg(0, std::ios::end);
@@ -241,13 +241,12 @@ bool WaveFileData::openFile ()
 
         _samples = std::vector<int16_t>(size/2); // size is in unit of byte, while one int_16 uses 2 bytes
         if (infile.read(reinterpret_cast<char*>(_samples.data()), size)) {
-            LOG("File data read");
-            LOG("Decoding is skipped since it is raw audio file");
+            debugstream << "File data read";
+            debugstream << "Decoding is skipped since it is raw audio file";
             return true;
         }
         else {
-            LOG("Unable to read from file : %s", _fileName.c_str());
-            FATAL(EXIT_INVALID_FILE, "Unable to read from file : %s", _fileName.c_str());
+            fatalstream(EXIT_INVALID_FILE) << "Unable to read from file : " << _fileName;
             return false;
         }
     }
@@ -263,29 +262,29 @@ bool WaveFileData::openFile ()
     std::istream_iterator<unsigned char> begin(infile), end;
     std::vector<unsigned char> fileData (begin, end);   //read complete file content
 
-    LOG("File data read and stored in buffer");
+    debugstream << "File data read and stored in buffer";
 
-    LOG("Processing data and extracting samples");
+    debugstream << "Processing data and extracting samples";
 
     if(checkValidWave(fileData))
     {
-        LOG("Wave File chunkID verification successful");
+        debugstream << "Wave File chunkID verification successful";
 
         _fileData = fileData;   //wave is valid, store and proceed
 
-        LOG("Begin decoding wave file");
+        debugstream << "Begin decoding wave file";
 
         decode();
 
-        LOG("File decoded successfully");
+        debugstream << "File decoded successfully";
 
         return true;
     }
 
     else
     {
-        LOG("Invalid WAV file");
-        FATAL(EXIT_INVALID_FILE, "Invalid WAV file!");
+        debugstream << "Invalid WAV file";
+        fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file!";
     }
 
     return true;
@@ -293,8 +292,8 @@ bool WaveFileData::openFile ()
 
 int WaveFileData::processStreamHeader()
 {
-    LOG("Processing Stream Header");
-    LOG("Checking chunkID, should be RIFF");
+    debugstream << "Processing Stream Header";
+    debugstream << "Checking chunkID, should be RIFF";
     unsigned char byteData;
     std::string riff ("RIFF"), wave ("WAVE");
     bool riffRead = false;                      //are 'RIFF' bytes read?
@@ -309,14 +308,14 @@ int WaveFileData::processStreamHeader()
         {
             if (riff[currentByteCount] != byteData)     //checking RIFF header
             {
-                FATAL(EXIT_INVALID_FILE, "Invalid WAV file : Incorrect subChunk1ID!");
+                fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file : Incorrect subChunk1ID!";
             }
 
             if (currentByteCount == 3)
             {
                 riffRead = true;
-                LOG("chunkID = RIFF confirmed!");
-                LOG("Checking WAV file header, should be WAVE");
+                debugstream << "chunkID = RIFF confirmed!";
+                debugstream << "Checking WAV file header, should be WAVE";
 
             }
         }
@@ -327,14 +326,14 @@ int WaveFileData::processStreamHeader()
             {
                 if (wave[currentByteCount - 8] != byteData) //checking WAVE format
                 {
-                    LOG("Error: Incorrect header");
-                    FATAL(EXIT_INVALID_FILE, "Invalid WAV file : Incorrect Header!");
+                    debugstream << "Error: Incorrect header";
+                    fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file : Incorrect Header!";
                 }
 
                 if (currentByteCount == 11)
                 {
                     return chunkSize - 8;
-                    LOG("wav header = WAVE confirmed!");
+                    debugstream << "wav header = WAVE confirmed!";
                 }
             }
 
@@ -344,14 +343,14 @@ int WaveFileData::processStreamHeader()
             }
         }
     }
-    LOG("Error occured while processing stream header!");
-    FATAL(EXIT_UNKNOWN, "Error occured while processing stream header!");
+    debugstream << "Error occured while processing stream header!";
+    fatalstream(EXIT_UNKNOWN) << "Error occured while processing stream header!";
     return -1;  //some error; more robust exit errors coming soon
 }
 
 int WaveFileData::seekToEndOfSubChunk1ID(int remainingBytes)
 {
-    LOG("Checking SubChunk1ID, should be fmt");
+    debugstream << "Checking SubChunk1ID, should be fmt";
 
     unsigned char byteData;
     std::string fmt ("fmt");
@@ -369,7 +368,7 @@ int WaveFileData::seekToEndOfSubChunk1ID(int remainingBytes)
 
             if(fmtCount == 3)           //definitely 'fmt'
             {
-                LOG("SubChunk1ID = fmt confirmed!");
+                debugstream << "SubChunk1ID = fmt confirmed!";
 
                 std::cin>>std::noskipws>>byteData;
                 _fileData.push_back(byteData);
@@ -385,18 +384,18 @@ int WaveFileData::seekToEndOfSubChunk1ID(int remainingBytes)
 
         if(readBytes > remainingBytes)
         {
-            LOG("SubChunk1 ('fmt') not found");
-            FATAL(EXIT_INVALID_FILE, "Invalid WAV file: SubChunk1 ('fmt') not found!");
+            debugstream << "SubChunk1 ('fmt') not found";
+            fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file: SubChunk1 ('fmt') not found!";
         }
     }
-    LOG("Error occured while checking SubChunk1ID");
-    FATAL(EXIT_UNKNOWN, "Error occured while checking SubChunk1ID");
+    debugstream << "Error occured while checking SubChunk1ID";
+    fatalstream(EXIT_UNKNOWN) << "Error occured while checking SubChunk1ID";
     return -1;
 }
 
 int WaveFileData::validateSubChunk1(int remainingBytes)
 {
-    LOG("Validating SubChunk1");
+    debugstream << "Validating SubChunk1";
 
     unsigned char byteData;
     std::vector<unsigned char> fmtBlock;
@@ -408,7 +407,7 @@ int WaveFileData::validateSubChunk1(int remainingBytes)
         _fileData.push_back(byteData);
         currentByteCount++;
         fmtBlock.push_back(byteData);               //storing 'fmt' data in a buffer, processing live is dangerous
-        LOG("Storing 'fmt' data in a buffer");
+        debugstream << "Storing 'fmt' data in a buffer";
 
         if(currentByteCount == 19)
         {
@@ -421,28 +420,28 @@ int WaveFileData::validateSubChunk1(int remainingBytes)
 
     if(subChunk1Size != 16)
     {
-        FATAL(EXIT_INVALID_FILE, "Invalid WAV file: Not PCM, SubChunk1Size: %lu", subChunk1Size);
+        fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file: Not PCM, SubChunk1Size: " << subChunk1Size;
     }
 
     int audioFormat = twoBytesToInt(fmtBlock, 4);
 
     if(audioFormat != 1)
     {
-        FATAL(EXIT_INVALID_FILE, "Invalid WAV file: Not PCM, AudioFormat: %d", audioFormat);
+        fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file: Not PCM, AudioFormat: " << audioFormat;
     }
 
     int numChannels = twoBytesToInt(fmtBlock, 6);
 
     if(numChannels != 1)
     {
-        FATAL(EXIT_INVALID_FILE, "Invalid WAV file: Not Mono, NumChannels: %d", numChannels);
+        fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file: Not Mono, NumChannels: " << numChannels;
     }
 
     unsigned long sampleRate = fourBytesToInt(fmtBlock, 8);
 
     if(sampleRate != 16000)
     {
-        FATAL(EXIT_INVALID_FILE, "Invalid WAV file: Not 16000Hz SampleRate, SampleRate: %lu", sampleRate);
+        fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file: Not 16000Hz SampleRate, SampleRate: " << sampleRate;
     }
 
     unsigned long byteRate = fourBytesToInt(fmtBlock, 12);
@@ -453,12 +452,12 @@ int WaveFileData::validateSubChunk1(int remainingBytes)
 
     if(bitRate != 16)
     {
-        FATAL(EXIT_INVALID_FILE, "Invalid WAV file: Not 16 bits/sec, BitRate: %d", bitRate);
+        fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file: Not 16 bits/sec, BitRate: " << bitRate;
     }
 
     if((byteRate != sampleRate * numChannels * bitRate/8) || (blockAlign != numChannels * bitRate/8))
     {
-        FATAL(EXIT_INVALID_FILE, "Incorrect header, ByteRate and/or BlockAlign values do not match!");
+        fatalstream(EXIT_INVALID_FILE) << "Incorrect header, ByteRate and/or BlockAlign values do not match!";
     }
 
     return currentByteCount + 1;
@@ -467,7 +466,7 @@ int WaveFileData::validateSubChunk1(int remainingBytes)
 
 int WaveFileData::seekToEndOfSubChunk2ID(int remainingBytes)
 {
-    LOG("Reading SubChunk2");
+    debugstream << "Reading SubChunk2";
 
     unsigned char byteData;
     //char *data = "data";
@@ -495,12 +494,12 @@ int WaveFileData::seekToEndOfSubChunk2ID(int remainingBytes)
 
         if(readBytes > remainingBytes)
         {
-            LOG("SubChunk2 ('data') not found");
-            FATAL(EXIT_INVALID_FILE, "SubChunk2 ('data') not found!");
+            debugstream << "SubChunk2 ('data') not found";
+            fatalstream(EXIT_INVALID_FILE) << "SubChunk2 ('data') not found!";
         }
     }
-    LOG("Error occured while reading SubChunk2");
-    FATAL(EXIT_UNKNOWN, "Error occured while reading SubChunk2!");
+    debugstream << "Error occured while reading SubChunk2";
+    fatalstream(EXIT_UNKNOWN) << "Error occured while reading SubChunk2!";
     return -1; //some error
 }
 
@@ -521,7 +520,7 @@ int WaveFileData::getNumberOfSamples()
 
 bool WaveFileData::readSamplesFromStream(int numberOfSamples)
 {
-    LOG("Reading and decoding samples from stream...");
+    debugstream << "Reading and decoding samples from stream...";
 
     unsigned char byteData;
     std::vector<unsigned char> twoBytes;
@@ -538,23 +537,23 @@ bool WaveFileData::readSamplesFromStream(int numberOfSamples)
         {
             int16_t sample = twoBytesToInt(twoBytes, 0);    //16 bit PCM, 2 bytes = 1 sample
             _samples.push_back(sample); //storing sample
-            LOG("Storing sample");
+            debugstream << "Storing sample";
             twoBytes.clear();
             two = 0;
         }
 
         if(bytesRead > numberOfSamples * 2)
         {
-            LOG("\nLooks like number of bytes exceeds the expected amount! Still processing.");
+            debugstream << "\nLooks like number of bytes exceeds the expected amount! Still processing.";
         }
     }
 
     if(bytesRead < numberOfSamples * 2)
     {
-		LOG("\nReceived less number of samples than the expected amount! Still processing.");
+		debugstream << "\nReceived less number of samples than the expected amount! Still processing.";
     }
 
-    LOG("Samples read and decoded!");
+    debugstream << "Samples read and decoded!";
 
 
     return -1;
@@ -563,9 +562,9 @@ bool WaveFileData::readSamplesFromStream(int numberOfSamples)
 
 bool WaveFileData::readStream()
 {
-    LOG("Reading WAV file from stream");
+    debugstream << "Reading WAV file from stream";
     if (_isRawFile) {
-        LOG("Raw audio mode is enabled. Turn to read stream using buffer...");
+        debugstream << "Raw audio mode is enabled. Turn to read stream using buffer...";
         return readStreamUsingBuffer();
     }
 
@@ -578,8 +577,8 @@ bool WaveFileData::readStream()
 
     if(remainingBytes != 2 * numberOfSamples)
     {
-        LOG("\nLooks like there is some error in reading samples from the file. Still proceeding.");
-        LOG("Potential error(s) in reading samples, still proceeding");
+        debugstream << "\nLooks like there is some error in reading samples from the file. Still proceeding.";
+        debugstream << "Potential error(s) in reading samples, still proceeding";
     }
 
     return readSamplesFromStream(numberOfSamples);              //reading samples
@@ -612,7 +611,7 @@ bool WaveFileData::readStreamUsingBuffer()
 
     else
     {
-        FATAL(EXIT_INVALID_FILE, "Invalid WAV file: SubChunk2 ('data') not found!");
+        fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file: SubChunk2 ('data') not found!";
     }
 
     return true;
@@ -621,20 +620,20 @@ bool WaveFileData::readStreamUsingBuffer()
 
 bool WaveFileData::read()   //decided the function based on set mode
 {
-    LOG("Begin reading WAV file");
+    debugstream << "Begin reading WAV file";
 
     switch (_openMode)
     {
-        case readFile             : LOG("Opening mode chosen: readFile, proceeding");
+        case readFile             : debugstream << "Opening mode chosen: readFile, proceeding";
                                     openFile();             //file on disk
                                     break;
-        case readStreamDirectly   : LOG("Opening mode chosen: readStreamDirectly, proceeding");
+        case readStreamDirectly   : debugstream << "Opening mode chosen: readStreamDirectly, proceeding";
                                     readStream();           //from stream/pipe
                                     break;
-        case readStreamIntoBuffer : LOG("Opening mode chosen: readStreamIntoBuffer, proceeding");
+        case readStreamIntoBuffer : debugstream << "Opening mode chosen: readStreamIntoBuffer, proceeding";
                                     readStreamUsingBuffer();//from stream/pipe into buffer and then processing
                                     break;
-        default                   : FATAL(EXIT_INVALID_FILE, "Error choosing opening mode, please report!");
+        default                   : fatalstream(EXIT_INVALID_FILE)<<"Error choosing opening mode, please report!";
 
     }
     return true;

--- a/src/lib_ccaligner/read_wav_file.cpp
+++ b/src/lib_ccaligner/read_wav_file.cpp
@@ -228,8 +228,7 @@ bool WaveFileData::openFile ()
 
     if (!infile)
     {
-        debugstream << "Error occured while opening file";
-        fatalstream(EXIT_FILE_NOT_FOUND, "Unable to open file : " << _fileName);
+        fatalstream(EXIT_FILE_NOT_FOUND) << "Unable to open file : " << _fileName;
     }
 
     debugstream << "Reading file data";

--- a/src/lib_ccaligner/read_wav_file.cpp
+++ b/src/lib_ccaligner/read_wav_file.cpp
@@ -531,13 +531,13 @@ bool WaveFileData::readSamplesFromStream(int numberOfSamples)
 
         if(bytesRead > numberOfSamples * 2)
         {
-            std::cout<<"\nLooks like number of bytes exceeds the expected amount! Still processing.";
+            LOG("\nLooks like number of bytes exceeds the expected amount! Still processing.");
         }
     }
 
     if(bytesRead < numberOfSamples * 2)
     {
-        std::cout<<"\nReceived less number of samples than the expected amount! Still processing.";
+		LOG("\nReceived less number of samples than the expected amount! Still processing.");
     }
 
     LOG("Samples read and decoded!");
@@ -564,7 +564,7 @@ bool WaveFileData::readStream()
 
     if(remainingBytes != 2 * numberOfSamples)
     {
-        std::cout<<"\nLooks like there is some error in reading samples from the file. Still proceeding.";
+        LOG("\nLooks like there is some error in reading samples from the file. Still proceeding.");
     }
 
     return readSamplesFromStream(numberOfSamples);              //reading samples

--- a/src/lib_ccaligner/read_wav_file.cpp
+++ b/src/lib_ccaligner/read_wav_file.cpp
@@ -33,7 +33,7 @@ bool WaveFileData::checkValidWave (const std::vector<unsigned char>& fileData)
      * 0         4   ChunkID          Contains the letters "RIFF" in ASCII form
      */
 
-    debugstream << "Checking chunkID, should be RIFF";
+    DEBUG << "Checking chunkID, should be RIFF";
     std::string chunkID (fileData.begin(), fileData.begin() + 4);
     return chunkID == "RIFF";
 
@@ -104,76 +104,76 @@ bool WaveFileData::decode()     //decodes the wave file
 
     if(format != "WAVE")
     {
-        debugstream << "Invalid WAV file format";
-        fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file format : " << format;
+        DEBUG << "Invalid WAV file format";
+        FATAL(EXIT_INVALID_FILE) << "Invalid WAV file format : " << format;
     }
 
-    debugstream << "File format is identified as WAV";
+    DEBUG << "File format is identified as WAV";
 
     /*
      * Apparently, this is just not it. The `fmt ` and `data`  chunk may not necessarily be in continuation.
      * There may occur inclusion of metadata. So, we'll need to find the location of these chunks.
      */
 
-    debugstream << "Finding FMT and DATA subchunks";
+    DEBUG << "Finding FMT and DATA subchunks";
 
     int fmtIndex = findIndex(_fileData, "fmt ");
     int dataIndex = findIndex(_fileData, "data");
 
     if(fmtIndex < 0)
     {
-        debugstream << "FMT subchunk not found!";
-        fatalstream(EXIT_INVALID_FILE) << "FMT subchunk not found!";
+        DEBUG << "FMT subchunk not found!";
+        FATAL(EXIT_INVALID_FILE) << "FMT subchunk not found!";
     }
 
     if(dataIndex < 0)
     {
-        debugstream << "Data subchunk not found!";
-        fatalstream(EXIT_INVALID_FILE) << "Data subchunk not found!";
+        DEBUG << "Data subchunk not found!";
+        FATAL(EXIT_INVALID_FILE) << "Data subchunk not found!";
     }
 
-    debugstream << "FMT index : "<< fmtIndex <<" , DATA index : " << dataIndex;
+    DEBUG << "FMT index : "<< fmtIndex <<" , DATA index : " << dataIndex;
 
     std::string subChunk1ID(_fileData.begin() + fmtIndex, _fileData.begin() + fmtIndex + 4);
 
     if(subChunk1ID != "fmt ")
     {
-        fatalstream(EXIT_INVALID_FILE) << "Invalid SubChunk1ID : " << subChunk1ID;
+        FATAL(EXIT_INVALID_FILE) << "Invalid SubChunk1ID : " << subChunk1ID;
     }
 
     unsigned long subChunk1Size = fourBytesToInt(_fileData, fmtIndex + 4);
 
     if(subChunk1Size != 16)
     {
-        fatalstream(EXIT_INVALID_FILE) << "Not PCM, SubChunk1Size : " << subChunk1Size;
+        FATAL(EXIT_INVALID_FILE) << "Not PCM, SubChunk1Size : " << subChunk1Size;
     }
 
     int audioFormat = twoBytesToInt(_fileData, fmtIndex + 8);
 
     if(audioFormat != 1)
     {
-        fatalstream(EXIT_INVALID_FILE) << "Not PCM, AudioFormat : " << audioFormat;
+        FATAL(EXIT_INVALID_FILE) << "Not PCM, AudioFormat : " << audioFormat;
     }
 
-    debugstream << "PCM : True";
+    DEBUG << "PCM : True";
 
     int numChannels = twoBytesToInt(_fileData, fmtIndex + 10);
 
     if(numChannels != 1)
     {
-        fatalstream(EXIT_INVALID_FILE) << "Not Mono, NumChannels : " << numChannels;
+        FATAL(EXIT_INVALID_FILE) << "Not Mono, NumChannels : " << numChannels;
     }
 
-    debugstream << "MONO : True";
+    DEBUG << "MONO : True";
 
     unsigned long sampleRate = fourBytesToInt(_fileData, fmtIndex + 12);
 
     if(sampleRate != 16000)
     {
-        fatalstream(EXIT_INVALID_FILE) << "Not 16000Hz SampleRate, SampleRate : " << sampleRate;
+        FATAL(EXIT_INVALID_FILE) << "Not 16000Hz SampleRate, SampleRate : " << sampleRate;
     }
 
-    debugstream << "Sample Rate 16KHz : True";
+    DEBUG << "Sample Rate 16KHz : True";
 
     unsigned long byteRate = fourBytesToInt(_fileData, fmtIndex + 16);
 
@@ -183,29 +183,29 @@ bool WaveFileData::decode()     //decodes the wave file
 
     if(bitRate != 16)
     {
-        fatalstream(EXIT_INVALID_FILE) << "Not 16 bits/sec, BitRate : " << bitRate;
+        FATAL(EXIT_INVALID_FILE) << "Not 16 bits/sec, BitRate : " << bitRate;
     }
 
-    debugstream << "BitRate 16 bits/sec : True";
+    DEBUG << "BitRate 16 bits/sec : True";
 
     if((byteRate != sampleRate * numChannels * bitRate/8) || (blockAlign != numChannels * bitRate/8))
     {
-        fatalstream(EXIT_INVALID_FILE) << "Incorrect header, ByteRate and/or BlockAlign values do not match!";
+        FATAL(EXIT_INVALID_FILE) << "Incorrect header, ByteRate and/or BlockAlign values do not match!";
     }
 
     std::string subChunk2ID (_fileData.begin() + dataIndex, _fileData.begin() + dataIndex + 4);
 
     if(subChunk2ID != "data")
     {
-        fatalstream(EXIT_INVALID_FILE) << "Invalid SubChunk2ID : " << subChunk2ID;
+        FATAL(EXIT_INVALID_FILE) << "Invalid SubChunk2ID : " << subChunk2ID;
     }
 
     unsigned long subChunk2Size = fourBytesToInt(_fileData, dataIndex + 4);
 
     unsigned long int numSamples = subChunk2Size * 8 / ( numChannels * bitRate);
 
-    debugstream << "Number of samples : " << numSamples;
-    debugstream << "Reading samples";
+    DEBUG << "Number of samples : " << numSamples;
+    DEBUG << "Reading samples";
 
     for (unsigned long int i = 0; i < numSamples; i++)
     {
@@ -216,7 +216,7 @@ bool WaveFileData::decode()     //decodes the wave file
             int16_t sample = twoBytesToInt(_fileData, sampleIndex);
             _samples.push_back(sample);
     }
-    debugstream << "Successfully decoded";
+    DEBUG << "Successfully decoded";
     return true;    //successfully decoded
 }
 
@@ -224,14 +224,14 @@ bool WaveFileData::openFile ()
 {
     std::ifstream infile (_fileName, std::ios::binary);
 
-    debugstream << "Trying to read from file : " << _fileName;
+    DEBUG << "Trying to read from file : " << _fileName;
 
     if (!infile)
     {
-        fatalstream(EXIT_FILE_NOT_FOUND) << "Unable to open file : " << _fileName;
+        FATAL(EXIT_FILE_NOT_FOUND) << "Unable to open file : " << _fileName;
     }
 
-    debugstream << "Reading file data";
+    DEBUG << "Reading file data";
 
     if (_isRawFile) { // handle raw audio files
         infile.seekg(0, std::ios::end);
@@ -240,12 +240,12 @@ bool WaveFileData::openFile ()
 
         _samples = std::vector<int16_t>(size/2); // size is in unit of byte, while one int_16 uses 2 bytes
         if (infile.read(reinterpret_cast<char*>(_samples.data()), size)) {
-            debugstream << "File data read";
-            debugstream << "Decoding is skipped since it is raw audio file";
+            DEBUG << "File data read";
+            DEBUG << "Decoding is skipped since it is raw audio file";
             return true;
         }
         else {
-            fatalstream(EXIT_INVALID_FILE) << "Unable to read from file : " << _fileName;
+            FATAL(EXIT_INVALID_FILE) << "Unable to read from file : " << _fileName;
             return false;
         }
     }
@@ -261,29 +261,29 @@ bool WaveFileData::openFile ()
     std::istream_iterator<unsigned char> begin(infile), end;
     std::vector<unsigned char> fileData (begin, end);   //read complete file content
 
-    debugstream << "File data read and stored in buffer";
+    DEBUG << "File data read and stored in buffer";
 
-    debugstream << "Processing data and extracting samples";
+    DEBUG << "Processing data and extracting samples";
 
     if(checkValidWave(fileData))
     {
-        debugstream << "Wave File chunkID verification successful";
+        DEBUG << "Wave File chunkID verification successful";
 
         _fileData = fileData;   //wave is valid, store and proceed
 
-        debugstream << "Begin decoding wave file";
+        DEBUG << "Begin decoding wave file";
 
         decode();
 
-        debugstream << "File decoded successfully";
+        DEBUG << "File decoded successfully";
 
         return true;
     }
 
     else
     {
-        debugstream << "Invalid WAV file";
-        fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file!";
+        DEBUG << "Invalid WAV file";
+        FATAL(EXIT_INVALID_FILE) << "Invalid WAV file!";
     }
 
     return true;
@@ -291,8 +291,8 @@ bool WaveFileData::openFile ()
 
 int WaveFileData::processStreamHeader()
 {
-    debugstream << "Processing Stream Header";
-    debugstream << "Checking chunkID, should be RIFF";
+    DEBUG << "Processing Stream Header";
+    DEBUG << "Checking chunkID, should be RIFF";
     unsigned char byteData;
     std::string riff ("RIFF"), wave ("WAVE");
     bool riffRead = false;                      //are 'RIFF' bytes read?
@@ -307,14 +307,14 @@ int WaveFileData::processStreamHeader()
         {
             if (riff[currentByteCount] != byteData)     //checking RIFF header
             {
-                fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file : Incorrect subChunk1ID!";
+                FATAL(EXIT_INVALID_FILE) << "Invalid WAV file : Incorrect subChunk1ID!";
             }
 
             if (currentByteCount == 3)
             {
                 riffRead = true;
-                debugstream << "chunkID = RIFF confirmed!";
-                debugstream << "Checking WAV file header, should be WAVE";
+                DEBUG << "chunkID = RIFF confirmed!";
+                DEBUG << "Checking WAV file header, should be WAVE";
 
             }
         }
@@ -325,14 +325,14 @@ int WaveFileData::processStreamHeader()
             {
                 if (wave[currentByteCount - 8] != byteData) //checking WAVE format
                 {
-                    debugstream << "Error: Incorrect header";
-                    fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file : Incorrect Header!";
+                    DEBUG << "Error: Incorrect header";
+                    FATAL(EXIT_INVALID_FILE) << "Invalid WAV file : Incorrect Header!";
                 }
 
                 if (currentByteCount == 11)
                 {
                     return chunkSize - 8;
-                    debugstream << "wav header = WAVE confirmed!";
+                    DEBUG << "wav header = WAVE confirmed!";
                 }
             }
 
@@ -342,14 +342,14 @@ int WaveFileData::processStreamHeader()
             }
         }
     }
-    debugstream << "Error occured while processing stream header!";
-    fatalstream(EXIT_UNKNOWN) << "Error occured while processing stream header!";
+    DEBUG << "Error occured while processing stream header!";
+    FATAL(EXIT_UNKNOWN) << "Error occured while processing stream header!";
     return -1;  //some error; more robust exit errors coming soon
 }
 
 int WaveFileData::seekToEndOfSubChunk1ID(int remainingBytes)
 {
-    debugstream << "Checking SubChunk1ID, should be fmt";
+    DEBUG << "Checking SubChunk1ID, should be fmt";
 
     unsigned char byteData;
     std::string fmt ("fmt");
@@ -367,7 +367,7 @@ int WaveFileData::seekToEndOfSubChunk1ID(int remainingBytes)
 
             if(fmtCount == 3)           //definitely 'fmt'
             {
-                debugstream << "SubChunk1ID = fmt confirmed!";
+                DEBUG << "SubChunk1ID = fmt confirmed!";
 
                 std::cin>>std::noskipws>>byteData;
                 _fileData.push_back(byteData);
@@ -383,18 +383,18 @@ int WaveFileData::seekToEndOfSubChunk1ID(int remainingBytes)
 
         if(readBytes > remainingBytes)
         {
-            debugstream << "SubChunk1 ('fmt') not found";
-            fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file: SubChunk1 ('fmt') not found!";
+            DEBUG << "SubChunk1 ('fmt') not found";
+            FATAL(EXIT_INVALID_FILE) << "Invalid WAV file: SubChunk1 ('fmt') not found!";
         }
     }
-    debugstream << "Error occured while checking SubChunk1ID";
-    fatalstream(EXIT_UNKNOWN) << "Error occured while checking SubChunk1ID";
+    DEBUG << "Error occured while checking SubChunk1ID";
+    FATAL(EXIT_UNKNOWN) << "Error occured while checking SubChunk1ID";
     return -1;
 }
 
 int WaveFileData::validateSubChunk1(int remainingBytes)
 {
-    debugstream << "Validating SubChunk1";
+    DEBUG << "Validating SubChunk1";
 
     unsigned char byteData;
     std::vector<unsigned char> fmtBlock;
@@ -406,7 +406,7 @@ int WaveFileData::validateSubChunk1(int remainingBytes)
         _fileData.push_back(byteData);
         currentByteCount++;
         fmtBlock.push_back(byteData);               //storing 'fmt' data in a buffer, processing live is dangerous
-        debugstream << "Storing 'fmt' data in a buffer";
+        DEBUG << "Storing 'fmt' data in a buffer";
 
         if(currentByteCount == 19)
         {
@@ -419,28 +419,28 @@ int WaveFileData::validateSubChunk1(int remainingBytes)
 
     if(subChunk1Size != 16)
     {
-        fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file: Not PCM, SubChunk1Size: " << subChunk1Size;
+        FATAL(EXIT_INVALID_FILE) << "Invalid WAV file: Not PCM, SubChunk1Size: " << subChunk1Size;
     }
 
     int audioFormat = twoBytesToInt(fmtBlock, 4);
 
     if(audioFormat != 1)
     {
-        fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file: Not PCM, AudioFormat: " << audioFormat;
+        FATAL(EXIT_INVALID_FILE) << "Invalid WAV file: Not PCM, AudioFormat: " << audioFormat;
     }
 
     int numChannels = twoBytesToInt(fmtBlock, 6);
 
     if(numChannels != 1)
     {
-        fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file: Not Mono, NumChannels: " << numChannels;
+        FATAL(EXIT_INVALID_FILE) << "Invalid WAV file: Not Mono, NumChannels: " << numChannels;
     }
 
     unsigned long sampleRate = fourBytesToInt(fmtBlock, 8);
 
     if(sampleRate != 16000)
     {
-        fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file: Not 16000Hz SampleRate, SampleRate: " << sampleRate;
+        FATAL(EXIT_INVALID_FILE) << "Invalid WAV file: Not 16000Hz SampleRate, SampleRate: " << sampleRate;
     }
 
     unsigned long byteRate = fourBytesToInt(fmtBlock, 12);
@@ -451,12 +451,12 @@ int WaveFileData::validateSubChunk1(int remainingBytes)
 
     if(bitRate != 16)
     {
-        fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file: Not 16 bits/sec, BitRate: " << bitRate;
+        FATAL(EXIT_INVALID_FILE) << "Invalid WAV file: Not 16 bits/sec, BitRate: " << bitRate;
     }
 
     if((byteRate != sampleRate * numChannels * bitRate/8) || (blockAlign != numChannels * bitRate/8))
     {
-        fatalstream(EXIT_INVALID_FILE) << "Incorrect header, ByteRate and/or BlockAlign values do not match!";
+        FATAL(EXIT_INVALID_FILE) << "Incorrect header, ByteRate and/or BlockAlign values do not match!";
     }
 
     return currentByteCount + 1;
@@ -465,7 +465,7 @@ int WaveFileData::validateSubChunk1(int remainingBytes)
 
 int WaveFileData::seekToEndOfSubChunk2ID(int remainingBytes)
 {
-    debugstream << "Reading SubChunk2";
+    DEBUG << "Reading SubChunk2";
 
     unsigned char byteData;
     //char *data = "data";
@@ -493,12 +493,12 @@ int WaveFileData::seekToEndOfSubChunk2ID(int remainingBytes)
 
         if(readBytes > remainingBytes)
         {
-            debugstream << "SubChunk2 ('data') not found";
-            fatalstream(EXIT_INVALID_FILE) << "SubChunk2 ('data') not found!";
+            DEBUG << "SubChunk2 ('data') not found";
+            FATAL(EXIT_INVALID_FILE) << "SubChunk2 ('data') not found!";
         }
     }
-    debugstream << "Error occured while reading SubChunk2";
-    fatalstream(EXIT_UNKNOWN) << "Error occured while reading SubChunk2!";
+    DEBUG << "Error occured while reading SubChunk2";
+    FATAL(EXIT_UNKNOWN) << "Error occured while reading SubChunk2!";
     return -1; //some error
 }
 
@@ -519,7 +519,7 @@ int WaveFileData::getNumberOfSamples()
 
 bool WaveFileData::readSamplesFromStream(int numberOfSamples)
 {
-    debugstream << "Reading and decoding samples from stream...";
+    DEBUG << "Reading and decoding samples from stream...";
 
     unsigned char byteData;
     std::vector<unsigned char> twoBytes;
@@ -536,23 +536,23 @@ bool WaveFileData::readSamplesFromStream(int numberOfSamples)
         {
             int16_t sample = twoBytesToInt(twoBytes, 0);    //16 bit PCM, 2 bytes = 1 sample
             _samples.push_back(sample); //storing sample
-            debugstream << "Storing sample";
+            DEBUG << "Storing sample";
             twoBytes.clear();
             two = 0;
         }
 
         if(bytesRead > numberOfSamples * 2)
         {
-            debugstream << "\nLooks like number of bytes exceeds the expected amount! Still processing.";
+            DEBUG << "\nLooks like number of bytes exceeds the expected amount! Still processing.";
         }
     }
 
     if(bytesRead < numberOfSamples * 2)
     {
-		debugstream << "\nReceived less number of samples than the expected amount! Still processing.";
+		DEBUG << "\nReceived less number of samples than the expected amount! Still processing.";
     }
 
-    debugstream << "Samples read and decoded!";
+    DEBUG << "Samples read and decoded!";
 
 
     return -1;
@@ -561,9 +561,9 @@ bool WaveFileData::readSamplesFromStream(int numberOfSamples)
 
 bool WaveFileData::readStream()
 {
-    debugstream << "Reading WAV file from stream";
+    DEBUG << "Reading WAV file from stream";
     if (_isRawFile) {
-        debugstream << "Raw audio mode is enabled. Turn to read stream using buffer...";
+        DEBUG << "Raw audio mode is enabled. Turn to read stream using buffer...";
         return readStreamUsingBuffer();
     }
 
@@ -576,8 +576,8 @@ bool WaveFileData::readStream()
 
     if(remainingBytes != 2 * numberOfSamples)
     {
-        debugstream << "\nLooks like there is some error in reading samples from the file. Still proceeding.";
-        debugstream << "Potential error(s) in reading samples, still proceeding";
+        DEBUG << "\nLooks like there is some error in reading samples from the file. Still proceeding.";
+        DEBUG << "Potential error(s) in reading samples, still proceeding";
     }
 
     return readSamplesFromStream(numberOfSamples);              //reading samples
@@ -610,7 +610,7 @@ bool WaveFileData::readStreamUsingBuffer()
 
     else
     {
-        fatalstream(EXIT_INVALID_FILE) << "Invalid WAV file: SubChunk2 ('data') not found!";
+        FATAL(EXIT_INVALID_FILE) << "Invalid WAV file: SubChunk2 ('data') not found!";
     }
 
     return true;
@@ -619,20 +619,20 @@ bool WaveFileData::readStreamUsingBuffer()
 
 bool WaveFileData::read()   //decided the function based on set mode
 {
-    debugstream << "Begin reading WAV file";
+    DEBUG << "Begin reading WAV file";
 
     switch (_openMode)
     {
-        case readFile             : debugstream << "Opening mode chosen: readFile, proceeding";
+        case readFile             : DEBUG << "Opening mode chosen: readFile, proceeding";
                                     openFile();             //file on disk
                                     break;
-        case readStreamDirectly   : debugstream << "Opening mode chosen: readStreamDirectly, proceeding";
+        case readStreamDirectly   : DEBUG << "Opening mode chosen: readStreamDirectly, proceeding";
                                     readStream();           //from stream/pipe
                                     break;
-        case readStreamIntoBuffer : debugstream << "Opening mode chosen: readStreamIntoBuffer, proceeding";
+        case readStreamIntoBuffer : DEBUG << "Opening mode chosen: readStreamIntoBuffer, proceeding";
                                     readStreamUsingBuffer();//from stream/pipe into buffer and then processing
                                     break;
-        default                   : fatalstream(EXIT_INVALID_FILE)<<"Error choosing opening mode, please report!";
+        default                   : FATAL(EXIT_INVALID_FILE)<<"Error choosing opening mode, please report!";
 
     }
     return true;

--- a/src/lib_ccaligner/recognize_using_pocketsphinx.cpp
+++ b/src/lib_ccaligner/recognize_using_pocketsphinx.cpp
@@ -32,17 +32,17 @@ PocketsphinxAligner::PocketsphinxAligner(Params* parameters) noexcept
     _parser(_subParserFactory.getParser())
     //_subtitles(_parser->getSubtitles())
 {
-    debugstream << "Initialising Aligner using PocketSphinx";
+    DEBUG << "Initialising Aligner using PocketSphinx";
 
     if (_parameters->usingTranscript) {
-        debugstream << "Audio Filename: " << _audioFileName << " Transcript filename: " << _transcriptFileName;
+        DEBUG << "Audio Filename: " << _audioFileName << " Transcript filename: " << _transcriptFileName;
     }
     else {
         _subtitles = _parser->getSubtitles();
-        debugstream << "Audio Filename: " << _audioFileName << " Subtitle filename: " << _subtitleFileName;
+        DEBUG << "Audio Filename: " << _audioFileName << " Subtitle filename: " << _subtitleFileName;
     }
 
-    infostream << "Reading and decoding audio samples...";
+    INFO << "Reading and decoding audio samples...";
 
     if (parameters->readStream)
         _file = decltype(_file)(new WaveFileData(readStreamDirectly, parameters->audioIsRaw));
@@ -54,13 +54,13 @@ PocketsphinxAligner::PocketsphinxAligner(Params* parameters) noexcept
 }
 
 bool PocketsphinxAligner::generateGrammar(grammarName name) {
-    debugstream << "Generating Grammar based on subtitles, Grammar Name: " << name;
+    DEBUG << "Generating Grammar based on subtitles, Grammar Name: " << name;
 
-    infostream << "Generating language model and grammar files...";
+    INFO << "Generating language model and grammar files...";
 
     if (_parameters->grammarType == complete_grammar || _parameters->grammarType == dict) {
-        infostream << "Note: You have chosen to generate a dictionary. Based on your TensorFlow configuration,";
-        infostream << "this may take some time, please be patient. For alternatives, see docs.";
+        INFO << "Note: You have chosen to generate a dictionary. Based on your TensorFlow configuration,";
+        INFO << "this may take some time, please be patient. For alternatives, see docs.";
     }
     bool ret;
     if (!_parameters->usingTranscript)
@@ -71,7 +71,7 @@ bool PocketsphinxAligner::generateGrammar(grammarName name) {
 }
 
 bool PocketsphinxAligner::initDecoder(const std::string& modelPath, const std::string& lmPath, const std::string& dictPath, const std::string& fsgPath, const std::string& logPath) {
-    debugstream << "Initialising PocketSphinx decoder";
+    DEBUG << "Initialising PocketSphinx decoder";
 
     _modelPath = modelPath;
     _lmPath = lmPath;
@@ -79,7 +79,7 @@ bool PocketsphinxAligner::initDecoder(const std::string& modelPath, const std::s
     _fsgPath = fsgPath;
     _logPath = logPath;
 
-    debugstream << "Configuration: \n\tmodelPath = " << _modelPath
+    DEBUG << "Configuration: \n\tmodelPath = " << _modelPath
         << "\n\tlmPath = " << _lmPath << "\n\tdictPath = " << _dictPath
         << "\n\tfsgPath = " << _fsgPath << "\n\tlogPath = " << _logPath;
 
@@ -139,13 +139,13 @@ bool PocketsphinxAligner::initDecoder(const std::string& modelPath, const std::s
 
 
     if (_configWord == nullptr) {
-        fatalstream(EXIT_FAILURE) << "Failed to create config object, see log for details";
+        FATAL(EXIT_FAILURE) << "Failed to create config object, see log for details";
     }
 
     _psWordDecoder = ps_init(_configWord);
 
     if (_psWordDecoder == nullptr) {
-        fatalstream(EXIT_FAILURE) << "Failed to create recognizer, see log for details";
+        FATAL(EXIT_FAILURE) << "Failed to create recognizer, see log for details";
     }
 
     if (_parameters->searchPhonemes) {
@@ -157,12 +157,12 @@ bool PocketsphinxAligner::initDecoder(const std::string& modelPath, const std::s
 
 
 bool PocketsphinxAligner::initPhonemeDecoder(const std::string& phoneticlmPath, const std::string& phonemeLogPath) {
-    debugstream << "Initialising PocketSphinx phoneme decoder";
+    DEBUG << "Initialising PocketSphinx phoneme decoder";
 
     _phoneticlmPath = phoneticlmPath;
     _phonemeLogPath = phonemeLogPath;
 
-    debugstream << "Configuration : \n\tphoneticlmPath = " << _phoneticlmPath << "\n\tphonemeLogPath = " << _phonemeLogPath;
+    DEBUG << "Configuration : \n\tphoneticlmPath = " << _phoneticlmPath << "\n\tphonemeLogPath = " << _phonemeLogPath;
 
     _configPhoneme = cmd_ln_init(nullptr,
         ps_args(), TRUE,
@@ -178,13 +178,13 @@ bool PocketsphinxAligner::initPhonemeDecoder(const std::string& phoneticlmPath, 
         nullptr);
 
     if (_configPhoneme == nullptr) {
-        fatalstream(EXIT_FAILURE) << "Failed to create config object, see log for details";
+        FATAL(EXIT_FAILURE) << "Failed to create config object, see log for details";
     }
 
     _psPhonemeDecoder = ps_init(_configPhoneme);
 
     if (_psPhonemeDecoder == nullptr) {
-        fatalstream(EXIT_FAILURE) << "Failed to create phoneme recognizer, see log for details";
+        FATAL(EXIT_FAILURE) << "Failed to create phoneme recognizer, see log for details";
     }
 
     return true;
@@ -300,7 +300,7 @@ recognisedBlock PocketsphinxAligner::findAndSetWordTimes(cmd_ln_t *config, ps_de
         endTime += ef * 1000 / frame_rate;
 
         if (startTime > endTime)
-            fatalstream(EXIT_INVALID_PARAMETERS) << "Error setting start and end time.";
+            FATAL(EXIT_INVALID_PARAMETERS) << "Error setting start and end time.";
 
         //storing recognised words and their timing information
         currentBlock.recognisedString.push_back(recognisedWord);
@@ -407,7 +407,7 @@ bool PocketsphinxAligner::recognise() {
         recognitionWindow = _sampleWindow;
     }
 
-    infostream << "Recognising and aligning..";
+    INFO << "Recognising and aligning..";
 
     for (SubtitleItem *sub : _subtitles) {
         if (sub->getDialogue().empty())
@@ -501,13 +501,13 @@ bool PocketsphinxAligner::recognise() {
         case karaoke:   subCount = printKaraokeContinuous(_outputFileName, subCount, sub, _parameters->printOption);
             break;
 
-        default:    fatalstream(EXIT_INVALID_PARAMETERS) << "An error occurred while choosing output format!";
+        default:    FATAL(EXIT_INVALID_PARAMETERS) << "An error occurred while choosing output format!";
         }
     }
 
     printFileEnd(_outputFileName, _parameters->outputFormat);
 
-    infostream << "Finished recognition and alignment..";
+    INFO << "Finished recognition and alignment..";
 
     return true;
 }
@@ -591,7 +591,7 @@ int PocketsphinxAligner::findTranscribedWordTimings(cmd_ln_t *config, ps_decoder
 }
 
 bool PocketsphinxAligner::transcribe() {
-    infostream << "Transcribing...";
+    INFO << "Transcribing...";
 
     //pointer to samples
     const int16_t *sample = _samples.data();
@@ -653,7 +653,7 @@ bool PocketsphinxAligner::transcribe() {
 
     printTranscriptionFooter(_outputFileName, _parameters->outputFormat);
 
-    infostream << "Finished transcription.";
+    INFO << "Finished transcription.";
 
     return true;
 }
@@ -776,7 +776,7 @@ bool PocketsphinxAligner::alignWithFSG() {
         case karaoke:   subCount = printKaraokeContinuous(_outputFileName, subCount, sub, _parameters->printOption);
             break;
 
-        default:        fatalstream(EXIT_UNKNOWN) << "An error occurred while choosing output format!";
+        default:        FATAL(EXIT_UNKNOWN) << "An error occurred while choosing output format!";
         }
 
 
@@ -803,7 +803,7 @@ bool PocketsphinxAligner::printAligned(const std::string& outputFileName, output
     case karaoke:   printKaraoke(outputFileName, _subtitles, _parameters->printOption);
         break;
 
-    default:        fatalstream(EXIT_FAILURE) << "An error occurred while choosing output format!";
+    default:        FATAL(EXIT_FAILURE) << "An error occurred while choosing output format!";
     }
 
     return true;

--- a/src/lib_ccaligner/recognize_using_pocketsphinx.cpp
+++ b/src/lib_ccaligner/recognize_using_pocketsphinx.cpp
@@ -35,12 +35,12 @@ bool PocketsphinxAligner::processFiles()
     LOG("Initialising Aligner using PocketSphinx");
     LOG("Audio Filename: %s Subtitle filename: %s", _audioFileName.c_str(), _subtitleFileName.c_str());
 
-    std::cout << "Reading and processing subtitles...\n";
+	LOG("Reading and processing subtitles...");
     _subParserFactory = std::unique_ptr<SubtitleParserFactory>(new SubtitleParserFactory(_subtitleFileName));
     _parser = _subParserFactory->getParser();
     _subtitles = _parser->getSubtitles();
 
-    std::cout << "Reading and decoding audio samples...\n";
+	LOG("Reading and decoding audio samples...");
     if(_parameters->readStream)
         _file = std::unique_ptr<WaveFileData>(new WaveFileData(readStreamDirectly, _parameters->audioIsRaw));
     else
@@ -57,12 +57,12 @@ bool PocketsphinxAligner::generateGrammar(grammarName name)
 {
     LOG("Generating Grammar based on subtitles, Grammar Name: %d ", name);
 
-    std::cout << "Generating language model and grammar files...\n";
+	LOG("Generating language model and grammar files...");
 
     if(_parameters->grammarType == complete_grammar || _parameters->grammarType == dict)
     {
-        std::cout << "Note: You have chosen to generate a dictionary. Based on your TensorFlow configuration,\n";
-        std::cout << "this may take some time, please be patient. For alternatives, see docs.\n";
+		LOG("Note: You have chosen to generate a dictionary. Based on your TensorFlow configuration,");
+		LOG("this may take some time, please be patient. For alternatives, see docs.");
     }
 
     return generate(_subtitles, name);
@@ -72,7 +72,6 @@ bool PocketsphinxAligner::initDecoder(const std::string& modelPath, const std::s
 {
     LOG("Initialising PocketSphinx decoder");
 
-    std::cout << "Initialising PocketSphinx decoder..\n";
     _modelPath = modelPath;
     _lmPath = lmPath;
     _dictPath = dictPath;
@@ -166,8 +165,6 @@ bool PocketsphinxAligner::initDecoder(const std::string& modelPath, const std::s
 bool PocketsphinxAligner::initPhonemeDecoder(const std::string& phoneticlmPath, const std::string& phonemeLogPath)
 {
     LOG("Initialising PocketSphinx phoneme decoder");
-
-    std::cout << "Initialising PocketSphinx phoneme decoder..\n";
 
     _phoneticlmPath = phoneticlmPath;
     _phonemeLogPath = phonemeLogPath;
@@ -435,7 +432,7 @@ bool PocketsphinxAligner::recognise()
         recognitionWindow = _sampleWindow;
     }
 
-    std::cout << "Recognising and aligning..\n";
+    LOG("Recognising and aligning..");
 
     for (SubtitleItem *sub : _subtitles)
     {
@@ -533,14 +530,14 @@ bool PocketsphinxAligner::recognise()
             case karaoke:   subCount = printKaraokeContinuous(_outputFileName, subCount, sub, _parameters->printOption);
                 break;
 
-            default:        std::cout<<"An error occurred while choosing output format!";
+            default:        FATAL(EXIT_UNKNOWN, "An error occurred while choosing output format!");
                 exit(2);
         }
     }
 
     printFileEnd(_outputFileName, _parameters->outputFormat);
 
-    std::cout << "Finished recognition and alignment..\n";
+    LOG("Finished recognition and alignment..");
 
     return true;
 }
@@ -634,7 +631,7 @@ int PocketsphinxAligner::findTranscribedWordTimings(cmd_ln_t *config, ps_decoder
 
 bool PocketsphinxAligner::transcribe()
 {
-    std::cout << "Transcribing...\n";
+    LOG("Transcribing...");
 
     //pointer to samples
     const int16_t *sample = _samples.data();
@@ -702,7 +699,7 @@ bool PocketsphinxAligner::transcribe()
 
     printTranscriptionFooter(_outputFileName, _parameters->outputFormat);
 
-    std::cout << "Finished transcription.\n";
+    LOG("Finished transcription.");
 
     return true;
 }
@@ -835,8 +832,7 @@ bool PocketsphinxAligner::alignWithFSG()
             case karaoke:   subCount = printKaraokeContinuous(_outputFileName, subCount, sub, _parameters->printOption);
                 break;
 
-            default:        std::cout<<"An error occurred while choosing output format!";
-                exit(2);
+            default:        FATAL(EXIT_UNKNOWN, "An error occurred while choosing output format!");
         }
 
 

--- a/src/lib_ccaligner/recognize_using_pocketsphinx.cpp
+++ b/src/lib_ccaligner/recognize_using_pocketsphinx.cpp
@@ -34,7 +34,7 @@ PocketsphinxAligner::PocketsphinxAligner(Params* parameters) noexcept
     debugstream << "Initialising Aligner using PocketSphinx";
     debugstream << "Audio Filename: " << _audioFileName << " Subtitle filename: " << _subtitleFileName;
         
-    debugstream << "Reading and decoding audio samples...";
+    infostream << "Reading and decoding audio samples...";
 
     if (parameters->readStream)
         _file = decltype(_file)(new WaveFileData(readStreamDirectly, parameters->audioIsRaw));
@@ -49,12 +49,12 @@ bool PocketsphinxAligner::generateGrammar(grammarName name)
 {
     debugstream << "Generating Grammar based on subtitles, Grammar Name: " << name;
 
-	debugstream << "Generating language model and grammar files...";
+	infostream << "Generating language model and grammar files...";
 
     if(_parameters->grammarType == complete_grammar || _parameters->grammarType == dict)
     {
-		debugstream << "Note: You have chosen to generate a dictionary. Based on your TensorFlow configuration,";
-		debugstream << "this may take some time, please be patient. For alternatives, see docs.";
+        infostream << "Note: You have chosen to generate a dictionary. Based on your TensorFlow configuration,";
+        infostream << "this may take some time, please be patient. For alternatives, see docs.";
     }
 
     return generate(_subtitles, name);
@@ -425,7 +425,7 @@ bool PocketsphinxAligner::recognise()
         recognitionWindow = _sampleWindow;
     }
 
-    debugstream << "Recognising and aligning..";
+    infostream << "Recognising and aligning..";
 
     for (SubtitleItem *sub : _subtitles)
     {
@@ -523,13 +523,13 @@ bool PocketsphinxAligner::recognise()
             case karaoke:   subCount = printKaraokeContinuous(_outputFileName, subCount, sub, _parameters->printOption);
                 break;
 
-            default:        fatalstream(EXIT_UNKNOWN)<<"An error occurred while choosing output format!";
+            default:    fatalstream(EXIT_INVALID_PARAMETERS)<<"An error occurred while choosing output format!";
         }
     }
 
     printFileEnd(_outputFileName, _parameters->outputFormat);
 
-    debugstream << "Finished recognition and alignment..";
+    infostream << "Finished recognition and alignment..";
 
     return true;
 }
@@ -539,7 +539,7 @@ bool PocketsphinxAligner::align()
     if(_parameters->grammarType != no_grammar)
         generateGrammar(_parameters->grammarType);
 
-    initDecoder(_parameters->modelPath, _parameters->lmPath, _parameters->dictPath, _parameters->fsgPath, _parameters->logPath);
+    initDecoder(_parameters->modelPath, _parameters->lmPath, _parameters->dictPath, _parameters->fsgPath, _parameters->alignerLogPath);
 
     if(_parameters->transcribe)
     {
@@ -623,7 +623,7 @@ int PocketsphinxAligner::findTranscribedWordTimings(cmd_ln_t *config, ps_decoder
 
 bool PocketsphinxAligner::transcribe()
 {
-    debugstream << "Transcribing...";
+    infostream << "Transcribing...";
 
     //pointer to samples
     const int16_t *sample = _samples.data();
@@ -691,7 +691,7 @@ bool PocketsphinxAligner::transcribe()
 
     printTranscriptionFooter(_outputFileName, _parameters->outputFormat);
 
-    debugstream << "Finished transcription.";
+    infostream << "Finished transcription.";
 
     return true;
 }

--- a/src/lib_ccaligner/recognize_using_pocketsphinx.cpp
+++ b/src/lib_ccaligner/recognize_using_pocketsphinx.cpp
@@ -20,7 +20,7 @@ PocketsphinxAligner::PocketsphinxAligner(Params* parameters) noexcept
     _lmPath(parameters->lmPath),
     _fsgPath(parameters->fsgPath),
     _logPath(parameters->logPath),
-    _phoneticLmPath(parameters->phoneticlmPath),
+    _phoneticLmPath(parameters->phoneticLmPath),
     _phonemeLogPath(parameters->phonemeLogPath),
 
     _audioWindow(parameters->audioWindow),
@@ -139,13 +139,13 @@ bool PocketsphinxAligner::initDecoder(const std::string& modelPath, const std::s
 
 
     if (_configWord == nullptr) {
-        FATAL(EXIT_FAILURE) << "Failed to create config object, see log for details";
+        FATAL(UnknownError) << "Failed to create config object, see log for details";
     }
 
     _psWordDecoder = ps_init(_configWord);
 
     if (_psWordDecoder == nullptr) {
-        FATAL(EXIT_FAILURE) << "Failed to create recognizer, see log for details";
+        FATAL(UnknownError) << "Failed to create recognizer, see log for details";
     }
 
     if (_parameters->searchPhonemes) {
@@ -178,13 +178,13 @@ bool PocketsphinxAligner::initPhonemeDecoder(const std::string& phoneticLmPath, 
         nullptr);
 
     if (_configPhoneme == nullptr) {
-        FATAL(EXIT_FAILURE) << "Failed to create config object, see log for details";
+        FATAL(UnknownError) << "Failed to create config object, see log for details";
     }
 
     _psPhonemeDecoder = ps_init(_configPhoneme);
 
     if (_psPhonemeDecoder == nullptr) {
-        FATAL(EXIT_FAILURE) << "Failed to create phoneme recognizer, see log for details";
+        FATAL(UnknownError) << "Failed to create phoneme recognizer, see log for details";
     }
 
     return true;
@@ -300,7 +300,7 @@ recognisedBlock PocketsphinxAligner::findAndSetWordTimes(cmd_ln_t *config, ps_de
         endTime += ef * 1000 / frame_rate;
 
         if (startTime > endTime)
-            FATAL(EXIT_INVALID_PARAMETERS) << "Error setting start and end time.";
+            FATAL(InvalidParameters) << "Error setting start and end time.";
 
         //storing recognised words and their timing information
         currentBlock.recognisedString.push_back(recognisedWord);
@@ -501,7 +501,7 @@ bool PocketsphinxAligner::recognise() {
         case karaoke:   subCount = printKaraokeContinuous(_outputFileName, subCount, sub, _parameters->printOption);
             break;
 
-        default:    FATAL(EXIT_INVALID_PARAMETERS) << "An error occurred while choosing output format!";
+        default:    FATAL(InvalidParameters) << "An error occurred while choosing output format!";
         }
     }
 
@@ -776,7 +776,7 @@ bool PocketsphinxAligner::alignWithFSG() {
         case karaoke:   subCount = printKaraokeContinuous(_outputFileName, subCount, sub, _parameters->printOption);
             break;
 
-        default:        FATAL(EXIT_UNKNOWN) << "An error occurred while choosing output format!";
+        default:        FATAL(UnknownError) << "An error occurred while choosing output format!";
         }
 
 
@@ -803,7 +803,7 @@ bool PocketsphinxAligner::printAligned(const std::string& outputFileName, output
     case karaoke:   printKaraoke(outputFileName, _subtitles, _parameters->printOption);
         break;
 
-    default:        FATAL(EXIT_FAILURE) << "An error occurred while choosing output format!";
+    default:        FATAL(UnknownError) << "An error occurred while choosing output format!";
     }
 
     return true;


### PR DESCRIPTION
This pull request implemented a stream-based, extensible Logger that differs outputs of different levels.
* It's extensible: It uses sinks to manage where it outputs to. You can set different minimum output level for each sink. Everything inheriting std::ostream can be a sink, like a file, or even a network server.
* It's also easy to use: you don't need to specify the types of the variable like %d, %s. It can automatically print the variable. Also, it is no longer limited to only the built-in types.
* Also, it's colorful :)
## Usage
To initialize:
```cpp
Logger::Sink sink(logFile, false); // logFile is a std::ofstrea;, false means don't use color for this sink.
sink.setMinimumOutputLevel(Logger::Level::verbose); // forward all logs to the log file.
getLogger().addSink(sink); // add a log file. (std::cout is automatically added)
```
To log:
```cpp
debugstream << "Creating temporary directories at tempFiles/";
infostream << "Grammar files created!";
fatalstream(EXIT_INVALID_PARAMETERS) << "Unsupported Aligner Type!";
```
## Screenshots
![linux_preview](https://user-images.githubusercontent.com/7413706/33661909-ce444100-dac4-11e7-99eb-620af2a41341.png)
![linux_log_saved](https://user-images.githubusercontent.com/7413706/33661910-cefb267c-dac4-11e7-94b0-94089fc25757.png)
![linux_colors](https://user-images.githubusercontent.com/7413706/33661913-cf7069c8-dac4-11e7-82dd-c1bf01bf16dd.png)
![win_levels](https://user-images.githubusercontent.com/7413706/33662152-c599dd48-dac5-11e7-91a9-ea328ec70315.png)
![win_1](https://user-images.githubusercontent.com/7413706/33662149-c4e3b39c-dac5-11e7-843d-d3e600f66207.png)
![win_2](https://user-images.githubusercontent.com/7413706/33662150-c521fb48-dac5-11e7-88b9-5c41114dcb15.png)
![use_verbosity](https://user-images.githubusercontent.com/7413706/33662151-c55e692a-dac5-11e7-958b-f4dc3ad9023e.png)
