### PR TITLE
Improve logger

### DIFF
--- a/src/lib_ccaligner/logger.h
+++ b/src/lib_ccaligner/logger.h
@@ -118,6 +118,25 @@ public:
     // Exception Type is used to indicate error when there is an exception. It is void for normal logs.
     template <class ExceptionType = Dummy>
     class Log {
+    private:
+        template<class E = ExceptionType>
+        typename std::enable_if<std::is_same<E, Dummy>::value>::type throwExceptionIfNeeded() noexcept {}
+        template<class E = ExceptionType>
+        typename std::enable_if<!std::is_same<E, Dummy>::value>::type throwExceptionIfNeeded() {
+            throw E(_ss.str());
+        }
+
+        static std::string getCurrentTime() {
+            char currentTime[16];
+            const auto now = std::time(nullptr);
+            std::strftime(currentTime, sizeof(currentTime), "%m-%d %H:%M:%S", std::localtime(&now));
+            return std::string(currentTime);
+        }
+
+        Logger& _logger;
+        std::stringstream _ss;
+        Level _level;
+
     public:
         Log(Logger& logger, const char* fileName, const char* funcName, int lineNumber, Level level)
             :_logger(logger), _level(level) {
@@ -144,25 +163,6 @@ public:
                     << "Reason: " << _ss.str() << std::endl;
             }
         }
-
-    private:
-        template<class E = ExceptionType>
-        typename std::enable_if<std::is_same<E, Dummy>::value>::type throwExceptionIfNeeded() noexcept {}
-        template<class E = ExceptionType>
-        typename std::enable_if<!std::is_same<E, Dummy>::value>::type throwExceptionIfNeeded() {
-            throw E(_ss.str());
-        }
-
-        static std::string getCurrentTime() {
-            char currentTime[16];
-            const auto now = std::time(nullptr);
-            std::strftime(currentTime, sizeof(currentTime), "%m-%d %H:%M:%S", std::localtime(&now));
-            return std::string(currentTime);
-        }
-
-        Logger& _logger;
-        std::stringstream _ss;
-        Level _level;
     };
 
     // It will apply the level to all **existing** sinks. Set level to nolog if you don't want any log.

--- a/src/lib_ccaligner/logger.h
+++ b/src/lib_ccaligner/logger.h
@@ -118,25 +118,6 @@ public:
     // Exception Type is used to indicate error when there is an exception. It is void for normal logs.
     template <class ExceptionType = Dummy>
     class Log {
-    private:
-        template<class E = ExceptionType>
-        typename std::enable_if<std::is_same<E, Dummy>::value>::type throwExceptionIfNeeded() noexcept {}
-        template<class E = ExceptionType>
-        typename std::enable_if<!std::is_same<E, Dummy>::value>::type throwExceptionIfNeeded() {
-            throw E(_ss.str());
-        }
-
-        static std::string getCurrentTime() {
-            char currentTime[16];
-            const auto now = std::time(nullptr);
-            std::strftime(currentTime, sizeof(currentTime), "%m-%d %H:%M:%S", std::localtime(&now));
-            return std::string(currentTime);
-        }
-
-        Logger& _logger;
-        std::stringstream _ss;
-        Level _level;
-
     public:
         Log(Logger& logger, const char* fileName, const char* funcName, int lineNumber, Level level)
             :_logger(logger), _level(level) {
@@ -150,7 +131,7 @@ public:
             return *this;
         }
 
-        ~Log() noexcept(noexcept(this->throwExceptionIfNeeded())) {
+        ~Log() noexcept(noexcept(std::is_same<ExceptionType, Dummy>::value)) {
             _ss << std::endl;
             _logger.log(_ss, _level);
             if (!std::uncaught_exception()) { // to avoid two uncaught exceptions.
@@ -163,6 +144,25 @@ public:
                     << "Reason: " << _ss.str() << std::endl;
             }
         }
+    private:
+            template<class E = ExceptionType>
+            typename std::enable_if<std::is_same<E, Dummy>::value>::type throwExceptionIfNeeded() noexcept {}
+            template<class E = ExceptionType>
+            typename std::enable_if<!std::is_same<E, Dummy>::value>::type throwExceptionIfNeeded() {
+                throw E(_ss.str());
+            }
+
+            static std::string getCurrentTime() {
+                char currentTime[16];
+                const auto now = std::time(nullptr);
+                std::strftime(currentTime, sizeof(currentTime), "%m-%d %H:%M:%S", std::localtime(&now));
+                return std::string(currentTime);
+            }
+
+            Logger& _logger;
+            std::stringstream _ss;
+            Level _level;
+
     };
 
     // It will apply the level to all **existing** sinks. Set level to nolog if you don't want any log.

--- a/src/lib_ccaligner/logger.h
+++ b/src/lib_ccaligner/logger.h
@@ -97,7 +97,7 @@ public:
             if (_useColor) _os << *colors[level];
             _os << ss.str();
             if (_useColor) _os << Colors::cdefault; // change back to the deafult color
-            if (level == error || level == fatal || true) flush(); // flush immediately to prevent data loss.
+            flush(); // flush immediately to prevent data loss.
         }
 
         // Set thte minimum output level.
@@ -131,7 +131,7 @@ public:
             return *this;
         }
 
-        ~Log() noexcept(false) {
+        ~Log() noexcept(noexcept(throwExceptionIfNeeded())) {
             _ss << std::endl;
             _logger.log(_ss, _level);
             if (!std::uncaught_exception()) { // to avoid two uncaught exceptions.
@@ -147,16 +147,16 @@ public:
 
     private:
         template<class E = ExceptionType>
-        typename std::enable_if<std::is_same<E, Dummy>::value>::type throwExceptionIfNeeded() {}
+        typename std::enable_if<std::is_same<E, Dummy>::value>::type throwExceptionIfNeeded() noexcept {}
         template<class E = ExceptionType>
-        typename std::enable_if<!std::is_same<E, Dummy>::value>::type throwExceptionIfNeeded() noexcept(false) {
+        typename std::enable_if<!std::is_same<E, Dummy>::value>::type throwExceptionIfNeeded() {
             throw E(_ss.str());
         }
 
         static std::string getCurrentTime() {
             char currentTime[16];
             const auto now = std::time(nullptr);
-            std::strftime(currentTime, 16, "%m-%d %H:%M:%S", std::localtime(&now));
+            std::strftime(currentTime, sizeof(currentTime), "%m-%d %H:%M:%S", std::localtime(&now));
             return std::string(currentTime);
         }
 

--- a/src/lib_ccaligner/logger.h
+++ b/src/lib_ccaligner/logger.h
@@ -150,7 +150,7 @@ public:
             return *this;
         }
 
-        ~Log() noexcept(noexcept(throwExceptionIfNeeded())) {
+        ~Log() noexcept(noexcept(this->throwExceptionIfNeeded())) {
             _ss << std::endl;
             _logger.log(_ss, _level);
             if (!std::uncaught_exception()) { // to avoid two uncaught exceptions.


### PR DESCRIPTION
Improve logger based on @Rakete1111 's suggestions.
1. Remove `noexcept(false)` for `throwExceptionIfNeeded`. add `noexcept` to the `throwExceptionIfNeeded` function that doesn't throw.
2. Replace hardcoding size with `sizeof(currentTime)`.
3. Remove debug code.
4. Make `Log`'s destructor conditionally be `noexcept` 