### PR TITLE
[Fix] Analyse samples only when they exist.

### DIFF
--- a/src/lib_ccaligner/generate_approx_timestamp.cpp
+++ b/src/lib_ccaligner/generate_approx_timestamp.cpp
@@ -73,7 +73,7 @@ inline int CurrentSub::getDuration (long startTime, long endTime) const noexcept
 {
     if(endTime < startTime)
     {
-        FATAL(InvalidFile) << "Error! Incorrect start time and end time of the dialogue.";
+        FATAL(InvalidFile) << "Error! Incorrect start time and end time of the dialogue. [Start : "<<startTime<<" | End : "<<endTime<<"]";
     }
 
     return endTime - startTime;

--- a/src/lib_ccaligner/grammar_tools.cpp
+++ b/src/lib_ccaligner/grammar_tools.cpp
@@ -182,7 +182,7 @@ void GenerateDict(bool generateQuickDict) // Generate dictionary from tensor flo
     }
     else
     {
-        INFO << "Creating the Dictionary, this might take a little time depending "
+        INFO << "Creating the Dictionary, this might take some time depending "
             "on your TensorFlow configuration : tempFiles/dict/complete.dict";
         int rv = systemGetStatus("g2p-seq2seq --decode tempFiles/vocab/complete.vocab --model g2p-seq2seq-cmudict/ > tempFiles/dict/complete.dict");
 

--- a/src/lib_ccaligner/logger.h
+++ b/src/lib_ccaligner/logger.h
@@ -111,7 +111,7 @@ public:
 
     private:
         std::ostream& _os;
-        Level _minimumOutputLevel = Level::debug;
+        Level _minimumOutputLevel = Level::verbose;
         bool _useColor;
     };
 


### PR DESCRIPTION
If subtitle frame exists beyond audio clip length, align approximately. Fixes #47 and closes #27 .