### PR TITLE
Rename "--model" parameter with "--model_dir" in g2p-seq2seq call

### DIFF
--- a/src/lib_ccaligner/grammar_tools.cpp
+++ b/src/lib_ccaligner/grammar_tools.cpp
@@ -184,7 +184,7 @@ void GenerateDict(bool generateQuickDict) // Generate dictionary from tensor flo
     {
         INFO << "Creating the Dictionary, this might take some time depending "
             "on your TensorFlow configuration : tempFiles/dict/complete.dict";
-        int rv = systemGetStatus("g2p-seq2seq --decode tempFiles/vocab/complete.vocab --model g2p-seq2seq-cmudict/ > tempFiles/dict/complete.dict");
+        int rv = systemGetStatus("g2p-seq2seq --decode tempFiles/vocab/complete.vocab --model_dir g2p-seq2seq-cmudict/ > tempFiles/dict/complete.dict");
 
         if (rv != 0)
         {


### PR DESCRIPTION
`g2p-seq2seq` has no `--model` parameter but it has a `--model_dir` one. See https://github.com/cmusphinx/g2p-seq2seq/blob/05d4e6bb09a095824ce9d039b349e9d875d2dcba/g2p_seq2seq/app.py#L35